### PR TITLE
ValidationUtils Bug Fix + Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.1-RC2]
+- Added tests to the core functionality to schemaValidator, refresher, client, core and models
+- Fixed the validation bug in SchemaValidationUtils. field.getType().isInstanceOf is a miss, Class.isAssignable is the correct way to check for class assignments.
+- Some minor code formatting and linting fixes
+
 ## [0.0.1-RC1]
 
 - A versioned schema registry, to register various schemas with all primitive and custom data-types, bound by a

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ And
 <dependency>
     <groupId>com.grookage.leia</groupId>
     <artifactId>leia-bom</artifactId>
-    <versio>0.0.1-RC1</version>
+    <versio>0.0.1-RC2</version>
 </dependency>
 ```
 

--- a/leia-bom/pom.xml
+++ b/leia-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
     </parent>
 
     <artifactId>leia-bom</artifactId>

--- a/leia-client-dropwizard/pom.xml
+++ b/leia-client-dropwizard/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/pom.xml
+++ b/leia-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 
@@ -76,6 +76,37 @@
         <dependency>
             <groupId>com.grookage.leia</groupId>
             <artifactId>leia-schema-validator</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <artifactId>mockito-core</artifactId>
+            <groupId>org.mockito</groupId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <groupId>org.mockito</groupId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <artifactId>mockito-inline</artifactId>
+            <groupId>org.mockito</groupId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <artifactId>leia-models</artifactId>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+            <groupId>com.grookage.leia</groupId>
         </dependency>
     </dependencies>
 

--- a/leia-client/src/main/java/com/grookage/leia/client/AbstractSchemaClient.java
+++ b/leia-client/src/main/java/com/grookage/leia/client/AbstractSchemaClient.java
@@ -40,6 +40,9 @@ public abstract class AbstractSchemaClient implements LeiaSchemaClient {
     }
 
     public List<SchemaDetails> getSchemaDetails(final Set<String> namespaces) {
+        if (null == refresher.getConfiguration()) {
+            throw new IllegalStateException("The configuration object has returned null data. Something gone wrong with refresher");
+        }
         return refresher.getConfiguration().stream()
                 .filter(each -> namespaces.contains(each.getSchemaKey().getNamespace())).toList();
     }

--- a/leia-client/src/test/java/com/grookage/leia/client/SchemaClientTest.java
+++ b/leia-client/src/test/java/com/grookage/leia/client/SchemaClientTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.client;
+
+import com.grookage.leia.client.refresher.LeiaClientRefresher;
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaKey;
+import com.grookage.leia.validator.LeiaSchemaValidator;
+import lombok.Builder;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Set;
+
+class SchemaClientTest {
+
+    static class TestableSchemaClient extends AbstractSchemaClient {
+
+        @Builder
+        public TestableSchemaClient(LeiaClientRefresher refresher, LeiaSchemaValidator schemaValidator) {
+            super(refresher, schemaValidator);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void testSchemaClient() {
+        final var clientRefresher = Mockito.mock(LeiaClientRefresher.class);
+        final var schemaValidator = Mockito.mock(LeiaSchemaValidator.class);
+        final var schemaClient = TestableSchemaClient.builder()
+                .refresher(clientRefresher)
+                .schemaValidator(schemaValidator)
+                .build();
+        Assertions.assertNull(schemaClient.getSchemaDetails());
+        Assertions.assertThrows(IllegalStateException.class, () -> schemaClient.getSchemaDetails(Set.of("testNamespace")));
+        Assertions.assertFalse(schemaClient.valid(SchemaKey.builder().build()));
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        Assertions.assertNotNull(schemaDetails);
+        final var schemaKey = schemaDetails.getSchemaKey();
+        Mockito.when(clientRefresher.getConfiguration()).thenReturn(List.of(schemaDetails));
+        final var details = schemaClient.getSchemaDetails();
+        Assertions.assertNotNull(details);
+        Assertions.assertTrue(schemaClient.getSchemaDetails(Set.of()).isEmpty());
+        Assertions.assertTrue(schemaClient.getSchemaDetails(Set.of("random")).isEmpty());
+        Assertions.assertFalse(schemaClient.getSchemaDetails(Set.of("testNamespace")).isEmpty());
+        Assertions.assertFalse(schemaClient.valid(schemaKey));
+    }
+}

--- a/leia-client/src/test/java/com/grookage/leia/client/datasource/NamespaceDataSourceTest.java
+++ b/leia-client/src/test/java/com/grookage/leia/client/datasource/NamespaceDataSourceTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.client.datasource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+class NamespaceDataSourceTest {
+
+    @Test
+    void testNamespaceDataSource() {
+        final var staticSource = new StaticNamespaceDataSource(Set.of("testNamespace"));
+        Assertions.assertNotNull(staticSource);
+        Assertions.assertNotNull(staticSource.getNamespaces());
+        Assertions.assertFalse(staticSource.getNamespaces().isEmpty());
+        final var supplier = new Supplier<Set<String>>() {
+
+            private static final AtomicReference<Boolean> supplierMarker = new AtomicReference<>(false);
+
+            @Override
+            public Set<String> get() {
+                return supplierMarker.get() ?
+                        Set.of("testNamespace") : Set.of();
+            }
+
+            public void mark() {
+                supplierMarker.set(true);
+            }
+        };
+        final var suppliedSource = new DynamicNamespaceDataSource(supplier);
+        Assertions.assertNotNull(suppliedSource.getNamespaces());
+        Assertions.assertTrue(suppliedSource.getNamespaces().isEmpty());
+
+        supplier.mark();
+        Assertions.assertNotNull(suppliedSource.getNamespaces());
+        Assertions.assertFalse(suppliedSource.getNamespaces().isEmpty());
+
+
+    }
+}

--- a/leia-core/pom.xml
+++ b/leia-core/pom.xml
@@ -21,15 +21,13 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 
     <artifactId>leia-core</artifactId>
 
-
     <dependencies>
-
         <dependency>
             <groupId>com.grookage.leia</groupId>
             <artifactId>leia-models</artifactId>
@@ -43,18 +41,6 @@
         <dependency>
             <groupId>com.grookage.leia</groupId>
             <artifactId>leia-refresher</artifactId>
-        </dependency>
-
-        <dependency>
-            <artifactId>leia-models</artifactId>
-            <type>test-jar</type>
-            <exclusions>
-                <exclusion>
-                    <artifactId>*</artifactId>
-                    <groupId>*</groupId>
-                </exclusion>
-            </exclusions>
-            <groupId>com.grookage.leia</groupId>
         </dependency>
 
         <dependency>
@@ -79,6 +65,25 @@
             <groupId>org.mockito</groupId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <artifactId>leia-models</artifactId>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+            <groupId>com.grookage.leia</groupId>
+        </dependency>
+
     </dependencies>
 
     <properties>

--- a/leia-core/src/main/java/com/grookage/leia/core/ingestion/hub/SchemaProcessorHub.java
+++ b/leia-core/src/main/java/com/grookage/leia/core/ingestion/hub/SchemaProcessorHub.java
@@ -45,18 +45,18 @@ public class SchemaProcessorHub {
     }
 
     public SchemaProcessorHub withSchemaRepository(SchemaRepository schemaRepository) {
-        Preconditions.checkNotNull(schemaRepository, "Schema Repository can't be null");
         this.schemaRepository = schemaRepository;
         return this;
     }
 
     public SchemaProcessorHub withVersionIDGenerator(VersionIDGenerator versionIDGenerator) {
-        Preconditions.checkNotNull(versionIDGenerator, "Version ID Generator can't be null");
         this.versionIDGenerator = versionIDGenerator;
         return this;
     }
 
     public SchemaProcessorHub build() {
+        Preconditions.checkNotNull(schemaRepository, "Schema Repository can't be null");
+        Preconditions.checkNotNull(versionIDGenerator, "Version ID Generator can't be null");
         Arrays.stream(SchemaEvent.values()).forEach(this::buildProcessor);
         return this;
     }

--- a/leia-core/src/main/java/com/grookage/leia/core/retrieval/SchemaRetriever.java
+++ b/leia-core/src/main/java/com/grookage/leia/core/retrieval/SchemaRetriever.java
@@ -23,6 +23,7 @@ import com.grookage.leia.models.schema.engine.SchemaState;
 import com.grookage.leia.repository.SchemaRepository;
 import com.grookage.leia.repository.config.CacheConfig;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -32,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
+@Getter
 public class SchemaRetriever {
 
     private final SchemaRepository schemaRepository;

--- a/leia-core/src/test/java/com/grookage/leia/core/ingestion/hub/SchemaProcessorHubTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/ingestion/hub/SchemaProcessorHubTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.core.ingestion.hub;
+
+import com.grookage.leia.core.ingestion.VersionIDGenerator;
+import com.grookage.leia.models.schema.engine.SchemaEvent;
+import com.grookage.leia.repository.SchemaRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SchemaProcessorHubTest {
+
+    @Test
+    void testSchemaProcessorHub() {
+        final var schemaRepository = Mockito.mock(SchemaRepository.class);
+        final var generator = new VersionIDGenerator() {
+            @Override
+            public String generateVersionId(String prefix) {
+                return "V1234";
+            }
+        };
+        final var hub = SchemaProcessorHub.of()
+                .withSchemaRepository(schemaRepository)
+                .withVersionIDGenerator(generator)
+                .build();
+        Assertions.assertNotNull(hub.getProcessor(SchemaEvent.CREATE_SCHEMA).orElse(null));
+        Assertions.assertThrows(NullPointerException.class, () -> SchemaProcessorHub.of()
+                .withVersionIDGenerator(generator)
+                .build());
+        Assertions.assertThrows(NullPointerException.class, () -> SchemaProcessorHub.of()
+                .withSchemaRepository(schemaRepository)
+                .build());
+    }
+}

--- a/leia-core/src/test/java/com/grookage/leia/core/ingestion/utils/ContextUtilsTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/ingestion/utils/ContextUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.core.ingestion.utils;
+
+import com.grookage.leia.core.exception.LeiaException;
+import com.grookage.leia.models.schema.engine.SchemaContext;
+import com.grookage.leia.models.user.SchemaUpdater;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ContextUtilsTest {
+
+    @Test
+    @SneakyThrows
+    void testContextUtils() {
+        Assertions.assertThrows(LeiaException.class, () -> ContextUtils.getEmail(new SchemaContext()));
+        Assertions.assertThrows(LeiaException.class, () -> ContextUtils.getUser(new SchemaContext()));
+        final var schemaContext = new SchemaContext();
+        ContextUtils.addSchemaUpdaterContext(schemaContext, new SchemaUpdater() {
+            @Override
+            public String name() {
+                return "name";
+            }
+
+            @Override
+            public String email() {
+                return "email";
+            }
+        });
+        Assertions.assertNotNull(ContextUtils.getEmail(schemaContext));
+        Assertions.assertNotNull(ContextUtils.getUser(schemaContext));
+    }
+}

--- a/leia-core/src/test/java/com/grookage/leia/core/ingestion/utils/SchemaUtilsTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/ingestion/utils/SchemaUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.core.ingestion.utils;
+
+import com.grookage.leia.core.ingestion.VersionIDGenerator;
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.attributes.DataType;
+import com.grookage.leia.models.schema.ingestion.CreateSchemaRequest;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SchemaUtilsTest {
+
+    @Test
+    @SneakyThrows
+    void testSchemaUtils() {
+        final var createSchemaRequest = ResourceHelper.getResource(
+                "schema/createSchemaRequest.json",
+                CreateSchemaRequest.class
+        );
+        final var generator = new VersionIDGenerator() {
+            @Override
+            public String generateVersionId(String prefix) {
+                return "V1234";
+            }
+        };
+        final var schemaDetails = SchemaUtils.toSchemaDetails(createSchemaRequest, "testUser",
+                "testEmail", generator
+        );
+        Assertions.assertNotNull(schemaDetails);
+        final var schemaKey = schemaDetails.getSchemaKey();
+        Assertions.assertNotNull(schemaKey);
+        Assertions.assertEquals("testNamespace", schemaKey.getNamespace());
+        Assertions.assertEquals("testSchema", schemaKey.getSchemaName());
+        Assertions.assertEquals("V1234", schemaKey.getVersion());
+        final var schemaMeta = schemaDetails.getSchemaMeta();
+        Assertions.assertNotNull(schemaMeta);
+        Assertions.assertEquals("testUser", schemaMeta.getCreatedBy());
+        final var schemaAttributes = schemaDetails.getAttributes();
+        Assertions.assertNotNull(schemaAttributes);
+        Assertions.assertTrue(schemaAttributes.stream().anyMatch(each -> each.getType() == DataType.ARRAY));
+    }
+}

--- a/leia-core/src/test/java/com/grookage/leia/core/retrieval/RepositoryRefresherTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/retrieval/RepositoryRefresherTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.core.retrieval;
+
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaKey;
+import com.grookage.leia.models.schema.SchemaRegistry;
+import com.grookage.leia.models.utils.LeiaUtils;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+class RepositoryRefresherTest {
+
+    @Test
+    @SneakyThrows
+    void testRepositoryRefresher() {
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        final var supplier = Mockito.mock(RepositorySupplier.class);
+        final var registry = SchemaRegistry.builder()
+                .build();
+        Mockito.when(supplier.get()).thenReturn(registry);
+        final var refresher = new RepositoryRefresher(supplier, 5);
+        Assertions.assertTrue(refresher.getConfiguration().getSchemas().isEmpty());
+        registry.add(schemaDetails);
+        LeiaUtils.sleepFor(6);
+        final var schemas = refresher.getConfiguration();
+        final var schema = schemas.getSchemaDetails(SchemaKey.builder()
+                .namespace("testNamespace")
+                .schemaName("testSchema")
+                .version("V1234")
+                .build()).orElse(null);
+        Assertions.assertNotNull(schema);
+
+    }
+}

--- a/leia-core/src/test/java/com/grookage/leia/core/retrieval/RepositorySupplierTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/retrieval/RepositorySupplierTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.core.retrieval;
+
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaKey;
+import com.grookage.leia.repository.SchemaRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Set;
+
+class RepositorySupplierTest {
+
+    @Test
+    @SneakyThrows
+    void testRepositorySupplier() {
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        final var repository = Mockito.mock(SchemaRepository.class);
+        final var supplier = new RepositorySupplier(repository);
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of(schemaDetails));
+        final var registry = supplier.get();
+        Assertions.assertFalse(registry.getSchemas().isEmpty());
+        final var schema = registry.getSchemaDetails(SchemaKey.builder()
+                .namespace("testNamespace")
+                .schemaName("testSchema")
+                .version("V1234")
+                .build()).orElse(null);
+        Assertions.assertNotNull(schema);
+    }
+}

--- a/leia-core/src/test/java/com/grookage/leia/core/retrieval/SchemaRetrieverTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/retrieval/SchemaRetrieverTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.core.retrieval;
+
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaKey;
+import com.grookage.leia.models.schema.engine.SchemaState;
+import com.grookage.leia.models.utils.LeiaUtils;
+import com.grookage.leia.repository.SchemaRepository;
+import com.grookage.leia.repository.config.CacheConfig;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class SchemaRetrieverTest {
+
+    private static SchemaRepository repository;
+
+    @BeforeEach
+    void setup() {
+        repository = Mockito.mock(SchemaRepository.class);
+    }
+
+    CacheConfig getCacheConfig() {
+        return CacheConfig.builder()
+                .enabled(true)
+                .refreshCacheSeconds(1)
+                .build();
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetSchemaDetailsCacheDisabled() {
+        final var retriever = new SchemaRetriever(repository, null);
+        Assertions.assertNull(retriever.getRefresher());
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        final var schemaKey = ResourceHelper
+                .getResource("schema/schemaKey.json", SchemaKey.class);
+        Mockito.when(repository.get(schemaKey))
+                .thenReturn(Optional.of(schemaDetails));
+        final var schemas = retriever.getSchemaDetails(schemaKey).orElse(null);
+        Assertions.assertNotNull(schemas);
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetSchemaDetailsCacheEnabled() {
+        final var cacheConfig = getCacheConfig();
+        final var retriever = new SchemaRetriever(repository, cacheConfig);
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        final var schemaKey = ResourceHelper
+                .getResource("schema/schemaKey.json", SchemaKey.class);
+        Mockito.when(repository.get(schemaKey))
+                .thenReturn(Optional.of(schemaDetails));
+        var schemas = retriever.getSchemaDetails(schemaKey).orElse(null);
+        Assertions.assertNull(schemas);
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of(schemaDetails));
+        LeiaUtils.sleepUntil(4);
+        schemas = retriever.getSchemaDetails(schemaKey).orElse(null);
+        Assertions.assertNotNull(schemas);
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetCurrentSchemasNoCache() {
+        final var retriever = new SchemaRetriever(repository, null);
+        Assertions.assertNull(retriever.getRefresher());
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        Mockito.when(repository.getSchemas(Set.of("testNamespace"), Set.of(SchemaState.APPROVED)))
+                .thenReturn(List.of());
+        var schemas = retriever.getCurrentSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        Mockito.when(repository.getSchemas(Set.of("testNamespace"), Set.of(SchemaState.APPROVED)))
+                .thenReturn(List.of(schemaDetails));
+        schemas = retriever.getCurrentSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertFalse(schemas.isEmpty());
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetCurrentSchemasWithCache() {
+        final var retriever = new SchemaRetriever(repository, getCacheConfig());
+        Assertions.assertNotNull(retriever.getRefresher());
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of());
+        var schemas = retriever.getCurrentSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of(schemaDetails));
+        LeiaUtils.sleepUntil(4);
+        schemas = retriever.getCurrentSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        schemaDetails.setSchemaState(SchemaState.APPROVED);
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of(schemaDetails));
+        LeiaUtils.sleepUntil(4);
+        schemas = retriever.getCurrentSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertFalse(schemas.isEmpty());
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetAllSchemasNoCache() {
+        final var retriever = new SchemaRetriever(repository, null);
+        Assertions.assertNull(retriever.getRefresher());
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        Mockito.when(repository.getSchemas(Set.of("testNamespace"), Set.of(SchemaState.APPROVED)))
+                .thenReturn(List.of());
+        var schemas = retriever.getAllSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        Mockito.when(repository.getSchemas(Set.of("testNamespace"), Arrays.stream(SchemaState.values()).collect(Collectors.toSet())))
+                .thenReturn(List.of());
+        schemas = retriever.getAllSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        Mockito.when(repository.getSchemas(Set.of("testNamespace"), Arrays.stream(SchemaState.values()).collect(Collectors.toSet())))
+                .thenReturn(List.of(schemaDetails));
+        schemas = retriever.getAllSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertFalse(schemas.isEmpty());
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetAllSchemasWithCache() {
+        final var retriever = new SchemaRetriever(repository, getCacheConfig());
+        Assertions.assertNotNull(retriever.getRefresher());
+        final var schemaDetails = ResourceHelper
+                .getResource("schema/schemaDetails.json", SchemaDetails.class);
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of());
+        var schemas = retriever.getAllSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of());
+        LeiaUtils.sleepUntil(4);
+        schemas = retriever.getAllSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertTrue(schemas.isEmpty());
+        Mockito.when(repository.getSchemas(Set.of(), Set.of()))
+                .thenReturn(List.of(schemaDetails));
+        LeiaUtils.sleepUntil(4);
+        schemas = retriever.getAllSchemaDetails(Set.of("testNamespace"));
+        Assertions.assertFalse(schemas.isEmpty());
+    }
+}

--- a/leia-dropwizard-es/pom.xml
+++ b/leia-dropwizard-es/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard/pom.xml
+++ b/leia-dropwizard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-elastic/pom.xml
+++ b/leia-elastic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-models/pom.xml
+++ b/leia-models/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 
@@ -84,6 +84,11 @@
             <groupId>org.aspectj</groupId>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/leia-models/src/main/java/com/grookage/leia/models/schema/SchemaKey.java
+++ b/leia-models/src/main/java/com/grookage/leia/models/schema/SchemaKey.java
@@ -24,6 +24,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Locale;
+
 @Builder
 @AllArgsConstructor
 @Data
@@ -36,7 +38,7 @@ public class SchemaKey {
 
     @JsonIgnore
     public String getReferenceId() {
-        return Joiner.on(".").join(namespace, schemaName, version);
+        return Joiner.on(".").join(namespace, schemaName, version).toUpperCase(Locale.ROOT);
     }
 
     @Override

--- a/leia-models/src/test/java/com/grookage/leia/models/utils/LeiaUtils.java
+++ b/leia-models/src/test/java/com/grookage/leia/models/utils/LeiaUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.models.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+import static org.awaitility.Awaitility.await;
+
+@UtilityClass
+public class LeiaUtils {
+
+    /*
+       If we know the upper bound condition, please use the until with the upper bound.
+       Only for cases, where you have to wait till the refreshInterval periods, don't want to introduce
+       refreshed and other boolean flags throughout the code.
+    */
+    public static void sleepUntil(int numSeconds) {
+        await().pollDelay(Duration.ofSeconds(numSeconds)).until(() -> true);
+    }
+
+    public static void sleepFor(int numSeconds) {
+        await().atMost(Duration.ofSeconds(numSeconds)).until(() -> true);
+    }
+
+    /*
+        Use this when you have to alter the numSeconds in any of the specific assertions. For finder and hub, the values are appropriately coded
+        keeping the start intervals in mind.
+     */
+    public static void sleepUntil(int numSeconds, Callable<Boolean> conditionEvaluator) {
+        await().pollDelay(Duration.ofSeconds(numSeconds)).until(conditionEvaluator);
+    }
+
+}

--- a/leia-parent/pom.xml
+++ b/leia-parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-bom</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-bom</relativePath>
     </parent>
 
@@ -46,7 +46,6 @@
         <guava-retrying.version>2.0.0</guava-retrying.version>
 
         <http.client.version>5.2.2</http.client.version>
-        <wiremock.version>3.3.1</wiremock.version>
         <mockito.version>4.2.0</mockito.version>
 
         <jackson.version>2.17.0</jackson.version>
@@ -55,6 +54,7 @@
         <aspectjrt.version>1.9.8</aspectjrt.version>
 
         <dropwizard.version>2.1.10</dropwizard.version>
+        <awaitility.version>4.1.1</awaitility.version>
     </properties>
 
     <dependencyManagement>
@@ -132,6 +132,12 @@
                 <groupId>org.mockito</groupId>
                 <scope>test</scope>
                 <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/leia-refresher/pom.xml
+++ b/leia-refresher/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 
@@ -29,6 +29,7 @@
 
     <properties>
         <okhttp.version>4.10.0</okhttp.version>
+        <wiremock.version>3.3.1</wiremock.version>
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 
@@ -81,6 +82,31 @@
             <version>${okhttp.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <artifactId>leia-models</artifactId>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+            <groupId>com.grookage.leia</groupId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/leia-refresher/src/main/java/com/grookage/leia/provider/config/LeiaHttpConfiguration.java
+++ b/leia-refresher/src/main/java/com/grookage/leia/provider/config/LeiaHttpConfiguration.java
@@ -56,11 +56,11 @@ public class LeiaHttpConfiguration {
 
     @Min(0)
     @Max(1024)
-    private int maxConcurrentRequests;
+    private int maxConcurrentRequests = 100;
 
     @Min(0)
     @Max(1024)
-    private int maxConcurrentRequestsPerHost;
+    private int maxConcurrentRequestsPerHost = 10;
 
     @Max(86400)
     @Builder.Default
@@ -74,6 +74,4 @@ public class LeiaHttpConfiguration {
     @Builder.Default
     private final int opTimeoutMs = 10000;
 
-    @Min(0L)
-    private int retryInterval;
 }

--- a/leia-refresher/src/main/java/com/grookage/leia/provider/endpoint/LeiaEndPoint.java
+++ b/leia-refresher/src/main/java/com/grookage/leia/provider/endpoint/LeiaEndPoint.java
@@ -16,6 +16,7 @@
 
 package com.grookage.leia.provider.endpoint;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Strings;
 import lombok.*;
 import okhttp3.HttpUrl;
@@ -28,10 +29,11 @@ import java.util.Locale;
 @Getter
 @Setter
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LeiaEndPoint {
 
     @Builder.Default
-    private EndPointScheme scheme = EndPointScheme.HTTP;
+    private EndPointScheme scheme = EndPointScheme.HTTPS;
     private String host;
     private int port;
     private String rootPathPrefix;

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/TimeBasedDataProviderTest.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/TimeBasedDataProviderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider;
+
+import com.grookage.leia.provider.stubs.TestSupplier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+
+
+class TimeBasedDataProviderTest {
+
+    @Test
+    void testTimeBasedProvider() {
+        final var testSupplier = new TestSupplier();
+        final var timeBasedProvider = new TimeBasedDataProvider<>(
+                testSupplier,
+                1,
+                TimeUnit.SECONDS
+        );
+        var testDetails = timeBasedProvider.getData();
+        Assertions.assertNull(testDetails);
+        timeBasedProvider.start();
+        testDetails = timeBasedProvider.getData();
+        Assertions.assertNotNull(testDetails);
+        Assertions.assertEquals("attribute1", testDetails.getAttribute1());
+        Assertions.assertEquals("attribute2", testDetails.getAttribute2());
+        Assertions.assertEquals("attribute3", testDetails.getAttribute3());
+        testSupplier.unmark();
+        await().pollDelay(Duration.ofSeconds(4)).until(testSupplier::referenceUnset);
+        testDetails = timeBasedProvider.getData();
+        Assertions.assertNotNull(testDetails);
+        Assertions.assertNull(testDetails.getAttribute1());
+        Assertions.assertNull(testDetails.getAttribute2());
+        Assertions.assertNull(testDetails.getAttribute3());
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/config/HttpConfigurationTest.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/config/HttpConfigurationTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.config;
+
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.provider.endpoint.EndPointScheme;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HttpConfigurationTest {
+
+    @Test
+    @SneakyThrows
+    void testHttpConfiguration() {
+        final var httpConfiguration = ResourceHelper.getResource(
+                "httpConfiguration.json",
+                LeiaHttpConfiguration.class
+        );
+        Assertions.assertNotNull(httpConfiguration);
+        Assertions.assertEquals("testHost", httpConfiguration.getHost());
+        Assertions.assertEquals(8080, httpConfiguration.getPort());
+        Assertions.assertEquals(EndPointScheme.HTTPS, httpConfiguration.getScheme());
+        Assertions.assertEquals(30, httpConfiguration.getRefreshTimeSeconds());
+        Assertions.assertNull(httpConfiguration.getRootPathPrefix());
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/endpoint/LeiaEndpointTest.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/endpoint/LeiaEndpointTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.endpoint;
+
+import com.grookage.leia.models.ResourceHelper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class LeiaEndpointTest {
+
+    @Test
+    @SneakyThrows
+    void testLeiaEndPoint() {
+        final var endPoint = ResourceHelper.getResource(
+                "endPoint.json",
+                LeiaEndPoint.class
+        );
+        Assertions.assertNotNull(endPoint);
+        Assertions.assertEquals("testHost", endPoint.getHost());
+        Assertions.assertEquals(8080, endPoint.getPort());
+        final var url = endPoint.url("/v1/test");
+        Assertions.assertNotNull(url);
+        Assertions.assertTrue("https://testHost:8080/v1/test".equalsIgnoreCase(url.toString()));
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/stubs/TestDetails.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/stubs/TestDetails.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.stubs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class TestDetails {
+
+    private String attribute1;
+    private String attribute2;
+    private String attribute3;
+
+    public static TestDetails getTestableDetails() {
+        return TestDetails.builder()
+                .attribute1("attribute1")
+                .attribute2("attribute2")
+                .attribute3("attribute3")
+                .build();
+    }
+
+    public static TestDetails getTestableDetailsDefault() {
+        return TestDetails.builder()
+                .build();
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/stubs/TestMarshaller.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/stubs/TestMarshaller.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.stubs;
+
+import com.grookage.leia.provider.marshal.Marshaller;
+
+public class TestMarshaller implements Marshaller<TestDetails> {
+    @Override
+    public TestDetails marshall(byte[] body) {
+        return TestDetails.getTestableDetails();
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/stubs/TestSupplier.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/stubs/TestSupplier.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.stubs;
+
+import com.grookage.leia.provider.suppliers.LeiaSupplier;
+import lombok.NoArgsConstructor;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@NoArgsConstructor
+public class TestSupplier implements LeiaSupplier<TestDetails> {
+
+    private static final AtomicReference<Boolean> testReference = new AtomicReference<>(true);
+
+
+    public boolean referenceUnset() {
+        return !testReference.get();
+    }
+
+    public void unmark() {
+        testReference.set(false);
+    }
+
+    public void mark() {
+        testReference.set(true);
+    }
+
+    @Override
+    public void start() {
+        //NOOP
+    }
+
+    @Override
+    public void stop() {
+        //NOOP
+    }
+
+    @Override
+    public TestDetails get() {
+        return testReference.get() ?
+                TestDetails.getTestableDetails() :
+                TestDetails.getTestableDetailsDefault();
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/suppliers/LeiaHttpSupplierTest.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/suppliers/LeiaHttpSupplierTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.suppliers;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.provider.config.LeiaHttpConfiguration;
+import com.grookage.leia.provider.endpoint.EndPointScheme;
+import com.grookage.leia.provider.stubs.TestDetails;
+import com.grookage.leia.provider.stubs.TestMarshaller;
+import lombok.SneakyThrows;
+import lombok.val;
+import okhttp3.Request;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+@SuppressWarnings("KotlinInternalInJava")
+@WireMockTest
+class LeiaHttpSupplierTest {
+
+    @Test
+    @SneakyThrows
+    void testHttpSupplier(WireMockRuntimeInfo wireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/v1/test"))
+                .willReturn(aResponse()
+                        .withBody(ResourceHelper.getObjectMapper().writeValueAsBytes(TestDetails.getTestableDetails()))
+                        .withStatus(200)));
+        val clientConfig = LeiaHttpConfiguration.builder()
+                .host("127.0.0.1")
+                .port(wireMockRuntimeInfo.getHttpPort())
+                .scheme(EndPointScheme.HTTP)
+                .build();
+        final var testableDetails = getSupplier(clientConfig).get();
+        Assertions.assertNotNull(testableDetails);
+        Assertions.assertEquals("attribute1", testableDetails.getAttribute1());
+        Assertions.assertEquals("attribute2", testableDetails.getAttribute2());
+        Assertions.assertEquals("attribute3", testableDetails.getAttribute3());
+    }
+
+    private LeiaHttpSupplier<TestDetails> getSupplier(LeiaHttpConfiguration clientConfig) {
+        return new LeiaHttpSupplier<>(clientConfig, new TestMarshaller(), "testSupplier") {
+            @Override
+            protected String url() {
+                return "/v1/test";
+            }
+
+            @Override
+            protected Request getRequest(String url) {
+                return new Request.Builder()
+                        .url(endPoint(url))
+                        .get()
+                        .build();
+            }
+        };
+    }
+}

--- a/leia-refresher/src/test/java/com/grookage/leia/provider/suppliers/LeiaSupplierTest.java
+++ b/leia-refresher/src/test/java/com/grookage/leia/provider/suppliers/LeiaSupplierTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.provider.suppliers;
+
+import com.grookage.leia.provider.stubs.TestSupplier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class LeiaSupplierTest {
+
+    @Test
+    void testLeiaSupplier() {
+        final var testableSupplier = new TestSupplier();
+        testableSupplier.mark();
+        final var testDetails = testableSupplier.get();
+        Assertions.assertNotNull(testDetails);
+        Assertions.assertEquals("attribute1", testDetails.getAttribute1());
+        Assertions.assertEquals("attribute2", testDetails.getAttribute2());
+        Assertions.assertEquals("attribute3", testDetails.getAttribute3());
+    }
+}

--- a/leia-refresher/src/test/resources/endPoint.json
+++ b/leia-refresher/src/test/resources/endPoint.json
@@ -1,0 +1,4 @@
+{
+  "host": "testHost",
+  "port": 8080
+}

--- a/leia-refresher/src/test/resources/httpConfiguration.json
+++ b/leia-refresher/src/test/resources/httpConfiguration.json
@@ -1,0 +1,4 @@
+{
+  "host": "testHost",
+  "port": 8080
+}

--- a/leia-repository/pom.xml
+++ b/leia-repository/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-schema-validator/pom.xml
+++ b/leia-schema-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC1</version>
+        <version>0.0.1-RC2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 
@@ -51,6 +51,19 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${guice.inject.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <artifactId>leia-models</artifactId>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+            <groupId>com.grookage.leia</groupId>
         </dependency>
     </dependencies>
 

--- a/leia-schema-validator/src/main/java/com/grookage/leia/validator/utils/SchemaValidationUtils.java
+++ b/leia-schema-validator/src/main/java/com/grookage/leia/validator/utils/SchemaValidationUtils.java
@@ -67,61 +67,66 @@ public class SchemaValidationUtils {
         if (null == field) {
             return attribute.isOptional();
         }
-        return attribute.accept(new SchemaAttributeAcceptor<>() {
+        return valid(field.getType(), attribute);
+    }
+
+    public static boolean valid(Class<?> fieldType, SchemaAttribute attribute) {
+        final Class<?> assignableKlass = attribute.accept(new SchemaAttributeAcceptor<>() {
             @Override
-            public Boolean accept(ArrayAttribute attribute) {
-                return field.getType().isInstance(Collection.class);
+            public Class<?> accept(ArrayAttribute attribute) {
+                return Collection.class;
             }
 
             @Override
-            public Boolean accept(BooleanAttribute attribute) {
-                return field.getType().isInstance(Boolean.class);
+            public Class<?> accept(BooleanAttribute attribute) {
+                return Boolean.class;
             }
 
             @Override
-            public Boolean accept(ByteAttribute attribute) {
-                return field.getType().isInstance(Byte.class);
+            public Class<?> accept(ByteAttribute attribute) {
+                return Byte.class;
             }
 
             @Override
-            public Boolean accept(DoubleAttribute attribute) {
-                return field.getType().isInstance(Double.class);
+            public Class<?> accept(DoubleAttribute attribute) {
+                return Double.class;
             }
 
             @Override
-            public Boolean accept(EnumAttribute attribute) {
-                return field.getType().isInstance(Enum.class);
+            public Class<?> accept(EnumAttribute attribute) {
+                return Enum.class;
             }
 
             @Override
-            public Boolean accept(FloatAttribute attribute) {
-                return field.getType().isInstance(Float.class);
+            public Class<?> accept(FloatAttribute attribute) {
+                return Float.class;
             }
 
             @Override
-            public Boolean accept(IntegerAttribute attribute) {
-                return field.getType().isInstance(Integer.class);
+            public Class<?> accept(IntegerAttribute attribute) {
+                return Integer.class;
             }
 
             @Override
-            public Boolean accept(LongAttribute attribute) {
-                return field.getType().isInstance(Long.class);
+            public Class<?> accept(LongAttribute attribute) {
+                return Long.class;
             }
 
             @Override
-            public Boolean accept(MapAttribute attribute) {
-                return field.getType().isInstance(Map.class);
+            public Class<?> accept(MapAttribute attribute) {
+                return Map.class;
             }
 
             @Override
-            public Boolean accept(ObjectAttribute attribute) {
-                return field.getType().isInstance(Object.class);
+            public Class<?> accept(ObjectAttribute attribute) {
+                return Object.class;
             }
 
             @Override
-            public Boolean accept(StringAttribute attribute) {
-                return field.getType().isInstance(String.class);
+            public Class<?> accept(StringAttribute attribute) {
+                return String.class;
             }
         });
+        return assignableKlass.isAssignableFrom(fieldType);
     }
 }

--- a/leia-schema-validator/src/test/java/com/grookage/leia/validator/SchemaValidationUtilsTest.java
+++ b/leia-schema-validator/src/test/java/com/grookage/leia/validator/SchemaValidationUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.validator;
+
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.attributes.*;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaValidationType;
+import com.grookage.leia.validator.exception.ValidationErrorCode;
+import com.grookage.leia.validator.utils.SchemaValidationUtils;
+import lombok.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+class SchemaValidationUtilsTest {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    static class ValidTestClass {
+        private Set<String> testAttribute;
+    }
+
+    @Test
+    @SneakyThrows
+    void testSchemaValidator() {
+        final var schemaDetails = ResourceHelper
+                .getResource("validSchema.json", SchemaDetails.class);
+        Assertions.assertNotNull(schemaDetails);
+        Assertions.assertTrue(SchemaValidationUtils.valid(schemaDetails, ValidTestClass.class));
+        schemaDetails.setValidationType(SchemaValidationType.STRICT);
+        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, ValidTestClass.class));
+    }
+
+    @Test
+    void testAllFields() {
+        final var arrayAttribute = new ArrayAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Set.class, arrayAttribute));
+
+        final var booleanAttribute = new BooleanAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Boolean.class, booleanAttribute));
+
+        final var byteAttribute = new ByteAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Byte.class, byteAttribute));
+
+        final var doubleAttribute = new DoubleAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Double.class, doubleAttribute));
+
+        final var enumAttribute = new EnumAttribute("testAttribute", true, null, Set.of());
+        Assertions.assertTrue(SchemaValidationUtils.valid(ValidationErrorCode.class, enumAttribute));
+
+        final var floatAttribute = new FloatAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Float.class, floatAttribute));
+
+        final var integerAttribute = new IntegerAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Integer.class, integerAttribute));
+
+        final var longAttribute = new LongAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Long.class, longAttribute));
+
+        final var mapAttribute = new MapAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(Map.class, mapAttribute));
+
+        final var objectAttribute = new ObjectAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaDetails.class, objectAttribute));
+
+        final var stringAttribute = new StringAttribute("testAttribute", true, null);
+        Assertions.assertTrue(SchemaValidationUtils.valid(String.class, stringAttribute));
+
+        Assertions.assertFalse(SchemaValidationUtils.valid(Long.class, integerAttribute));
+        Assertions.assertTrue(SchemaValidationUtils.valid(Long.class, objectAttribute));
+
+
+    }
+}

--- a/leia-schema-validator/src/test/resources/validSchema.json
+++ b/leia-schema-validator/src/test/resources/validSchema.json
@@ -1,0 +1,33 @@
+{
+  "schemaKey": {
+    "namespace": "testNamespace",
+    "schemaName": "testSchema",
+    "version": "V1234"
+  },
+  "schemaState": "CREATED",
+  "schemaType": "JSON",
+  "schemaMeta": {
+    "createdBy": "testUser"
+  },
+  "attributes": [
+    {
+      "type": "ARRAY",
+      "name": "testAttribute",
+      "optional": true,
+      "qualifierInfo": {
+        "type": "PII"
+      }
+    },
+    {
+      "type": "ENUM",
+      "name": "testAttribute2",
+      "optional": true,
+      "values": [
+        "TEST_ENUM"
+      ],
+      "qualifierInfo": {
+        "type": "PII"
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.leia</groupId>
     <artifactId>leia</artifactId>
-    <version>0.0.1-RC1</version>
+    <version>0.0.1-RC2</version>
     <packaging>pom</packaging>
 
     <name>Leia</name>
@@ -179,7 +179,6 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
- Added tests to the core functionality to schemaValidator, refresher, client, core and models
- Fixed the validation bug in SchemaValidationUtils. field.getType().isInstanceOf is a miss, Class.isAssignable is the correct way to check for class assignments.
- Some minor code formatting and linting fixes