### PR TITLE
Schema Violations and Marshaller bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [0.0.1-RC10]
+
+- LeiaSchemaViolation
+  - Introduced SchemaViolation & ViolationContext for generating violations as part of schema validation
+- SchemaValidationUtils: Returns list of LeiaSchemaViolations instead of boolean
+- StaticSchemaValidator: Updated to return all schema validation violations instead of stopping at the first error occurrence
+- LeiaClientMarshaller: Bug fix in serialization
+- Adds tests for `leia-schema-validator` module
+
 ## [0.0.1-RC9]
 
 - RollOverAndUpdate

--- a/leia-bom/pom.xml
+++ b/leia-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
     </parent>
 
     <artifactId>leia-bom</artifactId>

--- a/leia-client-dropwizard/pom.xml
+++ b/leia-client-dropwizard/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/pom.xml
+++ b/leia-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/src/main/java/com/grookage/leia/client/refresher/LeiaClientMarshaller.java
+++ b/leia-client/src/main/java/com/grookage/leia/client/refresher/LeiaClientMarshaller.java
@@ -21,6 +21,7 @@ import com.grookage.leia.models.schema.SchemaDetails;
 import com.grookage.leia.models.utils.MapperUtils;
 import com.grookage.leia.provider.marshal.Marshaller;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 
 import java.util.List;
 
@@ -30,9 +31,10 @@ public class LeiaClientMarshaller implements Marshaller<List<SchemaDetails>> {
         return new LeiaClientMarshaller();
     }
 
+    @SneakyThrows
     @Override
     public List<SchemaDetails> marshall(byte[] body) {
-        return MapperUtils.mapper().convertValue(body, new TypeReference<>() {
+        return MapperUtils.mapper().readValue(body, new TypeReference<>() {
         });
     }
 }

--- a/leia-common/pom.xml
+++ b/leia-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-common/src/main/java/com/grookage/leia/common/validation/SchemaPayloadValidator.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/validation/SchemaPayloadValidator.java
@@ -117,7 +117,7 @@ public class SchemaPayloadValidator {
             final var keyNode = entry.getKey() != null
                     ? MapperUtils.mapper().convertValue(entry.getKey(), JsonNode.class)
                     : null;
-            if (!Objects.isNull(keyNode)) {
+            if (Objects.nonNull(keyNode)) {
                 // validate Key
                 validateField(keyNode, mapAttribute.getKeyAttribute(), schemaValidationType, validationErrors);
                 // Validate value

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolation.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolation.java
@@ -1,0 +1,7 @@
+package com.grookage.leia.common.violation;
+
+public interface LeiaSchemaViolation {
+    String message();
+
+    String fieldPath();
+}

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolation.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolation.java
@@ -4,4 +4,6 @@ public interface LeiaSchemaViolation {
     String message();
 
     String fieldPath();
+
+    Class<?> rootKlass();
 }

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolation.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolation.java
@@ -1,9 +1,19 @@
 package com.grookage.leia.common.violation;
 
 public interface LeiaSchemaViolation {
+
+    /**
+     * @return Error message for the violation
+     */
     String message();
 
+    /**
+     * @return Relative path of the field being validated from the {@code rootKlass}
+     */
     String fieldPath();
 
+    /**
+     * @return Class of the field being validated
+     */
     Class<?> rootKlass();
 }

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolationImpl.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolationImpl.java
@@ -1,6 +1,7 @@
 package com.grookage.leia.common.violation;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,8 +32,10 @@ public class LeiaSchemaViolationImpl implements LeiaSchemaViolation {
     }
 
     public String toString() {
-        return Joiner.on(":")
-                .skipNulls()
-                .join(rootKlass, fieldPath, message);
+        if (Strings.isNullOrEmpty(fieldPath)) {
+            return String.format("[LeiaSchemaViolation] %s, message = %s", rootKlass, message);
+        }
+        return String.format("[LeiaSchemaViolation] %s, fieldPath = %s, message = %s", rootKlass,
+                fieldPath, message);
     }
 }

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolationImpl.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolationImpl.java
@@ -1,0 +1,30 @@
+package com.grookage.leia.common.violation;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeiaSchemaViolationImpl implements LeiaSchemaViolation {
+    private String message;
+    private String fieldPath;
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String fieldPath() {
+        return fieldPath;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[Violation] %s: %s", fieldPath, message);
+    }
+}

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolationImpl.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/LeiaSchemaViolationImpl.java
@@ -1,5 +1,6 @@
 package com.grookage.leia.common.violation;
 
+import com.google.common.base.Joiner;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class LeiaSchemaViolationImpl implements LeiaSchemaViolation {
     private String message;
     private String fieldPath;
+    private Class<?> rootKlass;
 
     @Override
     public String message() {
@@ -24,7 +26,13 @@ public class LeiaSchemaViolationImpl implements LeiaSchemaViolation {
     }
 
     @Override
+    public Class<?> rootKlass() {
+        return rootKlass;
+    }
+
     public String toString() {
-        return String.format("[Violation] %s: %s", fieldPath, message);
+        return Joiner.on(":")
+                .skipNulls()
+                .join(rootKlass, fieldPath, message);
     }
 }

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/ViolationContext.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/ViolationContext.java
@@ -5,30 +5,34 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.Set;
+import java.util.List;
 
 @Data
 @Builder
 @NoArgsConstructor
 public class ViolationContext {
     @Getter
-    private final Set<LeiaSchemaViolation> violations = new HashSet<>();
-    private final LinkedList<String> path = new LinkedList<>();
+    private final List<LeiaSchemaViolation> violations = new ArrayList<>();
+    private final LinkedList<Class<?>> klassPath = new LinkedList<>();
 
     public void addViolation(final String message) {
-        String fullPath = String.join(".", path);
-        violations.add(new LeiaSchemaViolationImpl(message, fullPath));
+        violations.add(new LeiaSchemaViolationImpl(message, null, klassPath.peekLast()));
     }
 
-    public void pushPath(final String element) {
-        path.addLast(element);
+    public void addViolation(final String message,
+                             final String path) {
+        violations.add(new LeiaSchemaViolationImpl(message, path, klassPath.peekLast()));
     }
 
-    public void popPath() {
-        if (!path.isEmpty()) {
-            path.removeLast();
+    public void pushClass(final Class<?> klass) {
+        klassPath.addLast(klass);
+    }
+
+    public void popClass() {
+        if (!klassPath.isEmpty()) {
+            klassPath.removeLast();
         }
     }
 }

--- a/leia-common/src/main/java/com/grookage/leia/common/violation/ViolationContext.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/violation/ViolationContext.java
@@ -1,0 +1,34 @@
+package com.grookage.leia.common.violation;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+public class ViolationContext {
+    @Getter
+    private final Set<LeiaSchemaViolation> violations = new HashSet<>();
+    private final LinkedList<String> path = new LinkedList<>();
+
+    public void addViolation(final String message) {
+        String fullPath = String.join(".", path);
+        violations.add(new LeiaSchemaViolationImpl(message, fullPath));
+    }
+
+    public void pushPath(final String element) {
+        path.addLast(element);
+    }
+
+    public void popPath() {
+        if (!path.isEmpty()) {
+            path.removeLast();
+        }
+    }
+}

--- a/leia-common/src/test/java/com/grookage/leia/common/utils/SchemaValidationUtilsTest.java
+++ b/leia-common/src/test/java/com/grookage/leia/common/utils/SchemaValidationUtilsTest.java
@@ -1,6 +1,8 @@
 package com.grookage.leia.common.utils;
 
 import com.grookage.leia.common.exception.ValidationErrorCode;
+import com.grookage.leia.common.stubs.NestedStub;
+import com.grookage.leia.common.stubs.PIIData;
 import com.grookage.leia.common.violation.ViolationContext;
 import com.grookage.leia.models.ResourceHelper;
 import com.grookage.leia.models.attributes.ArrayAttribute;
@@ -108,14 +110,14 @@ class SchemaValidationUtilsTest {
     @Test
     void testRawArray() {
         final var arrayAttribute = new ArrayAttribute("arrayAttribute", true, null, null);
-//        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-//                Set.of(arrayAttribute), RawSetTestClass.class, new ViolationContext()).isEmpty());
+        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
+                Set.of(arrayAttribute), RawSetTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
                 Set.of(arrayAttribute), SetTestClass.class, new ViolationContext()).isEmpty());
-//        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-//                Set.of(arrayAttribute), ListTestClass.class, new ViolationContext()).isEmpty());
-//        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-//                Set.of(arrayAttribute), ArrayTestClass.class, new ViolationContext()).isEmpty());
+        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
+                Set.of(arrayAttribute), ListTestClass.class, new ViolationContext()).isEmpty());
+        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
+                Set.of(arrayAttribute), ArrayTestClass.class, new ViolationContext()).isEmpty());
     }
 
     @Test
@@ -159,6 +161,23 @@ class SchemaValidationUtilsTest {
         final var arrayAttribute = new ArrayAttribute("arrayAttribute", true, null, listAttribute);
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(arrayAttribute),
                 GenericArrayTestClass.class, new ViolationContext()).isEmpty());
+    }
+
+    @SneakyThrows
+    @Test
+    void testInvalidNestedStubSchema() {
+        final var schemaDetails = ResourceHelper.getResource("invalidNestedStubSchema.json", SchemaDetails.class);
+        final var violations = SchemaValidationUtils.valid(schemaDetails, NestedStub.class);
+        Assertions.assertFalse(violations.isEmpty());
+        Assertions.assertEquals(4, violations.size());
+        final var nestedStubViolations = violations.stream()
+                .filter(leiaSchemaViolation -> leiaSchemaViolation.rootKlass().equals(NestedStub.class))
+                .toList();
+        Assertions.assertEquals(3, nestedStubViolations.size());
+        final var piiDataViolations = violations.stream()
+                .filter(leiaSchemaViolation -> leiaSchemaViolation.rootKlass().equals(PIIData.class))
+                .toList();
+        Assertions.assertEquals(1, piiDataViolations.size());
     }
 
     enum TestEnum {

--- a/leia-common/src/test/java/com/grookage/leia/common/utils/SchemaValidationUtilsTest.java
+++ b/leia-common/src/test/java/com/grookage/leia/common/utils/SchemaValidationUtilsTest.java
@@ -1,8 +1,19 @@
 package com.grookage.leia.common.utils;
 
 import com.grookage.leia.common.exception.ValidationErrorCode;
+import com.grookage.leia.common.violation.ViolationContext;
 import com.grookage.leia.models.ResourceHelper;
-import com.grookage.leia.models.attributes.*;
+import com.grookage.leia.models.attributes.ArrayAttribute;
+import com.grookage.leia.models.attributes.BooleanAttribute;
+import com.grookage.leia.models.attributes.ByteAttribute;
+import com.grookage.leia.models.attributes.DoubleAttribute;
+import com.grookage.leia.models.attributes.EnumAttribute;
+import com.grookage.leia.models.attributes.FloatAttribute;
+import com.grookage.leia.models.attributes.IntegerAttribute;
+import com.grookage.leia.models.attributes.LongAttribute;
+import com.grookage.leia.models.attributes.MapAttribute;
+import com.grookage.leia.models.attributes.ObjectAttribute;
+import com.grookage.leia.models.attributes.StringAttribute;
 import com.grookage.leia.models.schema.SchemaDetails;
 import com.grookage.leia.models.schema.SchemaValidationType;
 import lombok.SneakyThrows;
@@ -21,9 +32,9 @@ class SchemaValidationUtilsTest {
         final var schemaDetails = ResourceHelper
                 .getResource("validSchema.json", SchemaDetails.class);
         Assertions.assertNotNull(schemaDetails);
-        Assertions.assertTrue(SchemaValidationUtils.valid(schemaDetails, ValidTestClass.class));
+        Assertions.assertTrue(SchemaValidationUtils.valid(schemaDetails, ValidTestClass.class).isEmpty());
         schemaDetails.setValidationType(SchemaValidationType.STRICT);
-        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, ValidTestClass.class));
+        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, ValidTestClass.class).isEmpty());
     }
 
     @Test
@@ -33,7 +44,7 @@ class SchemaValidationUtilsTest {
                 .getResource("validSchema.json", SchemaDetails.class);
         schemaDetails.setValidationType(SchemaValidationType.MATCHING);
         Assertions.assertNotNull(schemaDetails);
-        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, InvalidTestClass.class));
+        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, InvalidTestClass.class).isEmpty());
     }
 
     @Test
@@ -85,26 +96,26 @@ class SchemaValidationUtilsTest {
         final var stringAttribute = new StringAttribute("stringAttribute", true, null);
         final var arrayAttribute = new ArrayAttribute("arrayAttribute", true, null, stringAttribute);
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(arrayAttribute),
-                SetTestClass.class));
+                SetTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(arrayAttribute),
-                ListTestClass.class));
+                ListTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(arrayAttribute),
-                ArrayTestClass.class));
+                ArrayTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertFalse(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(arrayAttribute),
-                RawSetTestClass.class));
+                RawSetTestClass.class, new ViolationContext()).isEmpty());
     }
 
     @Test
     void testRawArray() {
         final var arrayAttribute = new ArrayAttribute("arrayAttribute", true, null, null);
+//        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
+//                Set.of(arrayAttribute), RawSetTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-                Set.of(arrayAttribute), RawSetTestClass.class));
-        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-                Set.of(arrayAttribute), SetTestClass.class));
-        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-                Set.of(arrayAttribute), ListTestClass.class));
-        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
-                Set.of(arrayAttribute), ArrayTestClass.class));
+                Set.of(arrayAttribute), SetTestClass.class, new ViolationContext()).isEmpty());
+//        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
+//                Set.of(arrayAttribute), ListTestClass.class, new ViolationContext()).isEmpty());
+//        Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING,
+//                Set.of(arrayAttribute), ArrayTestClass.class, new ViolationContext()).isEmpty());
     }
 
     @Test
@@ -113,22 +124,22 @@ class SchemaValidationUtilsTest {
         final var valueAttribute = new StringAttribute("valueAttribute", true, null);
         final var mapAttribute = new MapAttribute("mapAttribute", true, null, keyAttribute, valueAttribute);
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(mapAttribute),
-                MapTestClass.class));
+                MapTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(mapAttribute),
-                ConcurrentMapTestClass.class));
+                ConcurrentMapTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertFalse(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(mapAttribute),
-                RawMapTestClass.class));
+                RawMapTestClass.class, new ViolationContext()).isEmpty());
     }
 
     @Test
     void testRawMap() {
         final var mapAttribute = new MapAttribute("mapAttribute", true, null, null, null);
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(mapAttribute),
-                RawMapTestClass.class));
+                RawMapTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(mapAttribute),
-                MapTestClass.class));
+                MapTestClass.class, new ViolationContext()).isEmpty());
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(mapAttribute),
-                ConcurrentMapTestClass.class));
+                ConcurrentMapTestClass.class, new ViolationContext()).isEmpty());
     }
 
     @Test
@@ -137,8 +148,8 @@ class SchemaValidationUtilsTest {
         final var schemaDetails = ResourceHelper
                 .getResource("validNestedSchema.json", SchemaDetails.class);
         schemaDetails.setValidationType(SchemaValidationType.MATCHING);
-        Assertions.assertTrue(SchemaValidationUtils.valid(schemaDetails, ValidObjectTestClass.class));
-        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, InvalidObjectTestClass.class));
+        Assertions.assertTrue(SchemaValidationUtils.valid(schemaDetails, ValidObjectTestClass.class).isEmpty());
+        Assertions.assertFalse(SchemaValidationUtils.valid(schemaDetails, InvalidObjectTestClass.class).isEmpty());
     }
 
     @Test
@@ -147,7 +158,7 @@ class SchemaValidationUtilsTest {
         final var listAttribute = new ArrayAttribute("listAttribute", true, null, stringAttribute);
         final var arrayAttribute = new ArrayAttribute("arrayAttribute", true, null, listAttribute);
         Assertions.assertTrue(SchemaValidationUtils.valid(SchemaValidationType.MATCHING, Set.of(arrayAttribute),
-                GenericArrayTestClass.class));
+                GenericArrayTestClass.class, new ViolationContext()).isEmpty());
     }
 
     enum TestEnum {

--- a/leia-common/src/test/resources/invalidNestedStubSchema.json
+++ b/leia-common/src/test/resources/invalidNestedStubSchema.json
@@ -1,0 +1,92 @@
+{
+  "namespace": "testNamespace",
+  "schemaName": "NestedStub",
+  "version": "V1234",
+  "schemaState": "CREATED",
+  "schemaType": "JSON",
+  "validationType": "STRICT",
+  "schemaMeta": {
+    "createdBy": "testUser"
+  },
+  "attributes": [
+    {
+      "type": "INTEGER",
+      "name": "phoneNumber",
+      "optional": false,
+      "qualifiers": [
+        {
+          "type": "PII"
+        }
+      ]
+    },
+    {
+      "type": "OBJECT",
+      "name": "piiData",
+      "optional": false,
+      "qualifiers": [
+        {
+          "type": "ENCRYPTED"
+        },
+        {
+          "type": "PII"
+        }
+      ],
+      "nestedAttributes": [
+        {
+          "type": "STRING",
+          "name": "accountNumber",
+          "optional": false,
+          "qualifiers": [
+            {
+              "type": "ENCRYPTED"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "LONG",
+      "name": "id",
+      "optional": false,
+      "qualifiers": []
+    },
+    {
+      "type": "ENUM",
+      "name": "enumClass",
+      "optional": false,
+      "qualifiers": [],
+      "values": [
+        "ONE",
+        "TWO"
+      ]
+    },
+    {
+      "type": "OBJECT",
+      "name": "recordStub",
+      "optional": false,
+      "qualifiers": [
+        {
+          "type": "ENCRYPTED"
+        }
+      ],
+      "nestedAttributes": [
+        {
+          "type": "INTEGER",
+          "name": "id",
+          "optional": true,
+          "qualifiers": []
+        },
+        {
+          "type": "STRING",
+          "name": "name",
+          "optional": false,
+          "qualifiers": [
+            {
+              "type": "PII"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/leia-core/pom.xml
+++ b/leia-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard-es/pom.xml
+++ b/leia-dropwizard-es/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard/pom.xml
+++ b/leia-dropwizard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-elastic/pom.xml
+++ b/leia-elastic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-models/pom.xml
+++ b/leia-models/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-parent/pom.xml
+++ b/leia-parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-bom</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-bom</relativePath>
     </parent>
 

--- a/leia-refresher/pom.xml
+++ b/leia-refresher/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-repository/pom.xml
+++ b/leia-repository/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-schema-validator/pom.xml
+++ b/leia-schema-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC9</version>
+        <version>0.0.1-RC10</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-schema-validator/pom.xml
+++ b/leia-schema-validator/pom.xml
@@ -56,6 +56,17 @@
             <artifactId>commons-lang3</artifactId>
             <version>${lang3.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.grookage.leia</groupId>
+            <artifactId>leia-models</artifactId>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
     </dependencies>
 

--- a/leia-schema-validator/src/main/java/com/grookage/leia/validator/StaticSchemaValidator.java
+++ b/leia-schema-validator/src/main/java/com/grookage/leia/validator/StaticSchemaValidator.java
@@ -52,7 +52,7 @@ public class StaticSchemaValidator implements LeiaSchemaValidator {
     }
 
     @SneakyThrows
-    private Set<LeiaSchemaViolation> validate(final SchemaKey schemaKey, Class<?> klass) {
+    private List<LeiaSchemaViolation> validate(final SchemaKey schemaKey, Class<?> klass) {
         final var details = supplier.get().stream()
                 .filter(each -> each.match(schemaKey)).findFirst().orElse(null);
         if (null == details) {
@@ -64,7 +64,7 @@ public class StaticSchemaValidator implements LeiaSchemaValidator {
     @Override
     public void start() {
         log.info("Starting the schema validator");
-        Map<SchemaKey, Set<LeiaSchemaViolation>> violations = new HashMap<>();
+        Map<SchemaKey, List<LeiaSchemaViolation>> violations = new HashMap<>();
         packageRoots.forEach(handlerPackage -> {
             final var reflections = new Reflections(handlerPackage);
             final var annotatedClasses = reflections.getTypesAnnotatedWith(SchemaDefinition.class);

--- a/leia-schema-validator/src/main/java/com/grookage/leia/validator/StaticSchemaValidator.java
+++ b/leia-schema-validator/src/main/java/com/grookage/leia/validator/StaticSchemaValidator.java
@@ -28,11 +28,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 

--- a/leia-schema-validator/src/main/java/com/grookage/leia/validator/StaticSchemaValidator.java
+++ b/leia-schema-validator/src/main/java/com/grookage/leia/validator/StaticSchemaValidator.java
@@ -56,7 +56,8 @@ public class StaticSchemaValidator implements LeiaSchemaValidator {
         final var details = supplier.get().stream()
                 .filter(each -> each.match(schemaKey)).findFirst().orElse(null);
         if (null == details) {
-            throw SchemaValidationException.error(ValidationErrorCode.NO_SCHEMA_FOUND);
+            throw SchemaValidationException.error(ValidationErrorCode.NO_SCHEMA_FOUND,
+                    String.format("No schema found with key: %s", schemaKey.getReferenceId()));
         }
         return SchemaValidationUtils.valid(details, klass);
     }
@@ -85,7 +86,10 @@ public class StaticSchemaValidator implements LeiaSchemaValidator {
         });
         if (!violations.isEmpty()) {
             log.error("Found invalid schemas. Please fix the following schemas to start the bundle {}", violations);
-            throw SchemaValidationException.error(ValidationErrorCode.INVALID_SCHEMAS);
+            throw SchemaValidationException.builder()
+                    .errorCode(ValidationErrorCode.INVALID_SCHEMAS)
+                    .context(Map.of("schemaViolations", violations))
+                    .build();
         }
     }
 

--- a/leia-schema-validator/src/test/java/com/grookage/leia/validator/StaticSchemaValidatorTest.java
+++ b/leia-schema-validator/src/test/java/com/grookage/leia/validator/StaticSchemaValidatorTest.java
@@ -1,0 +1,95 @@
+package com.grookage.leia.validator;
+
+import com.grookage.leia.common.builder.SchemaBuilder;
+import com.grookage.leia.common.exception.SchemaValidationException;
+import com.grookage.leia.common.exception.ValidationErrorCode;
+import com.grookage.leia.models.ResourceHelper;
+import com.grookage.leia.models.annotations.SchemaDefinition;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaKey;
+import com.grookage.leia.models.schema.SchemaMeta;
+import com.grookage.leia.models.schema.engine.SchemaState;
+import com.grookage.leia.validator.stubs.TestNestedRecordStub;
+import com.grookage.leia.validator.stubs.TestRecordStub;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+class StaticSchemaValidatorTest {
+    private static final String PACKAGE = "com.grookage.leia.validator.stubs";
+
+    @Test
+    void testSchemaValidator() {
+        final var recordStubDetails = toSchemaDetails(TestRecordStub.class);
+        final var nestedStubDetails = toSchemaDetails(TestNestedRecordStub.class);
+        final var schemaValidator = StaticSchemaValidator.builder()
+                .packageRoots(Set.of(PACKAGE))
+                .supplier(() -> List.of(recordStubDetails, nestedStubDetails))
+                .build();
+        Assertions.assertDoesNotThrow(schemaValidator::start);
+        Assertions.assertTrue(schemaValidator.valid(schemaKey(TestRecordStub.class)));
+        Assertions.assertTrue(schemaValidator.valid(schemaKey(TestNestedRecordStub.class)));
+    }
+
+    @Test
+    void testSchemaValidator_withMissingSchemaDetails() {
+        final var recordStubDetails = toSchemaDetails(TestRecordStub.class);
+        final var schemaValidator = StaticSchemaValidator.builder()
+                .packageRoots(Set.of(PACKAGE))
+                .supplier(() -> List.of(recordStubDetails))
+                .build();
+        final var schemaValidationException = Assertions.assertThrows(SchemaValidationException.class, schemaValidator::start);
+        Assertions.assertEquals(ValidationErrorCode.NO_SCHEMA_FOUND.name(), schemaValidationException.getCode());
+    }
+
+    @SneakyThrows
+    @Test
+    void testSchemaValidator_withInvalidSchema() {
+        final var recordStubDetails = ResourceHelper.getResource("InvalidRecordStubSchema.json", SchemaDetails.class);
+        final var nestedStubDetails = ResourceHelper.getResource("InvalidNestedRecordStubSchema.json", SchemaDetails.class);
+        final var schemaValidator = StaticSchemaValidator.builder()
+                .packageRoots(Set.of(PACKAGE))
+                .supplier(() -> List.of(recordStubDetails, nestedStubDetails))
+                .build();
+        final var schemaValidationException = Assertions.assertThrows(SchemaValidationException.class, schemaValidator::start);
+        Assertions.assertEquals(ValidationErrorCode.INVALID_SCHEMAS.name(), schemaValidationException.getCode());
+        Assertions.assertFalse(schemaValidator.valid(schemaKey(TestRecordStub.class)));
+        Assertions.assertFalse(schemaValidator.valid(schemaKey(TestNestedRecordStub.class)));
+    }
+
+
+    private SchemaDetails toSchemaDetails(final Class<?> schemaKlass) {
+        final var schemaDefinition = schemaKlass.getAnnotation(SchemaDefinition.class);
+        final var createSchemaRequest = SchemaBuilder.buildSchemaRequest(schemaKlass)
+                .orElse(null);
+        Assertions.assertNotNull(createSchemaRequest);
+        return SchemaDetails.builder()
+                .namespace(schemaDefinition.namespace())
+                .schemaName(schemaDefinition.name())
+                .version(schemaDefinition.version())
+                .schemaState(SchemaState.CREATED)
+                .schemaType(createSchemaRequest.getSchemaType())
+                .description(createSchemaRequest.getDescription())
+                .attributes(createSchemaRequest.getAttributes())
+                .schemaMeta(SchemaMeta.builder()
+                        .createdBy("testUser")
+                        .createdByEmail("testEmail")
+                        .createdAt(System.currentTimeMillis())
+                        .build())
+                .validationType(createSchemaRequest.getValidationType())
+                .transformationTargets(createSchemaRequest.getTransformationTargets())
+                .build();
+    }
+
+    private SchemaKey schemaKey(final Class<?> schemaKlass) {
+        final var schemaDefinition = schemaKlass.getAnnotation(SchemaDefinition.class);
+        return SchemaKey.builder()
+                .schemaName(schemaDefinition.name())
+                .namespace(schemaDefinition.namespace())
+                .version(schemaDefinition.version())
+                .build();
+    }
+}

--- a/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestData.java
+++ b/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestData.java
@@ -1,0 +1,17 @@
+package com.grookage.leia.validator.stubs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TestData {
+    int id;
+    String name;
+    Object object;
+    TestEnum testEnum;
+}

--- a/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestEnum.java
+++ b/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestEnum.java
@@ -1,0 +1,6 @@
+package com.grookage.leia.validator.stubs;
+
+public enum TestEnum {
+    ONE,
+    TWO;
+}

--- a/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestNestedRecordStub.java
+++ b/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestNestedRecordStub.java
@@ -1,0 +1,35 @@
+package com.grookage.leia.validator.stubs;
+
+import com.grookage.leia.models.annotations.SchemaDefinition;
+import com.grookage.leia.models.annotations.attribute.Optional;
+import com.grookage.leia.models.annotations.attribute.qualifiers.Encrypted;
+import com.grookage.leia.models.annotations.attribute.qualifiers.PII;
+import com.grookage.leia.models.schema.SchemaType;
+import com.grookage.leia.models.schema.SchemaValidationType;
+
+import java.util.List;
+import java.util.Map;
+
+@SchemaDefinition(
+        name = TestNestedRecordStub.NAME,
+        namespace = TestNestedRecordStub.NAMESPACE,
+        version = TestNestedRecordStub.VERSION,
+        description = TestNestedRecordStub.DESCRIPTION,
+        type = SchemaType.JSON,
+        validation = SchemaValidationType.STRICT
+)
+public class TestNestedRecordStub {
+    static final String NAME = "TEST_NESTED_RECORD";
+    static final String NAMESPACE = "test";
+    static final String VERSION = "v1";
+    static final String DESCRIPTION = "Test Nested Record";
+
+    @PII
+    @Encrypted
+    String accountNumber;
+    @Optional
+    String accountId;
+    TestData testData;
+    Map<TestEnum, TestData> enumTestDataMap;
+    List<String> strings;
+}

--- a/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestRecordStub.java
+++ b/leia-schema-validator/src/test/java/com/grookage/leia/validator/stubs/TestRecordStub.java
@@ -1,0 +1,32 @@
+package com.grookage.leia.validator.stubs;
+
+import com.grookage.leia.models.annotations.SchemaDefinition;
+import com.grookage.leia.models.annotations.attribute.Optional;
+import com.grookage.leia.models.annotations.attribute.qualifiers.Encrypted;
+import com.grookage.leia.models.annotations.attribute.qualifiers.PII;
+import com.grookage.leia.models.schema.SchemaType;
+import com.grookage.leia.models.schema.SchemaValidationType;
+
+@SchemaDefinition(
+        name = TestRecordStub.NAME,
+        namespace = TestRecordStub.NAMESPACE,
+        version = TestRecordStub.VERSION,
+        description = TestRecordStub.DESCRIPTION,
+        type = SchemaType.JSON,
+        validation = SchemaValidationType.STRICT
+)
+public class TestRecordStub {
+    static final String NAME = "TEST_RECORD";
+    static final String NAMESPACE = "test";
+    static final String VERSION = "v1";
+    static final String DESCRIPTION = "Test Record";
+
+    int id;
+    String name;
+    @PII
+    @Encrypted
+    String accountNumber;
+    long ttl;
+    @Optional
+    String accountId;
+}

--- a/leia-schema-validator/src/test/resources/InvalidNestedRecordStubSchema.json
+++ b/leia-schema-validator/src/test/resources/InvalidNestedRecordStubSchema.json
@@ -1,0 +1,113 @@
+{
+  "namespace" : "test",
+  "schemaName" : "TEST_NESTED_RECORD",
+  "version" : "v1",
+  "description" : "Test Nested Record",
+  "schemaState" : "CREATED",
+  "schemaType" : "JSON",
+  "validationType" : "STRICT",
+  "schemaMeta" : {
+    "createdBy" : "testUser",
+    "createdByEmail" : "testEmail",
+    "createdAt" : 1733897687017,
+    "updatedBy" : null,
+    "updatedByEmail" : null,
+    "updatedAt" : 0
+  },
+  "attributes" : [ {
+    "type" : "OBJECT",
+    "name" : "testData",
+    "optional" : false,
+    "qualifiers" : [ ],
+    "nestedAttributes" : [ {
+      "type" : "OBJECT",
+      "name" : "object",
+      "optional" : false,
+      "qualifiers" : [ ],
+      "nestedAttributes" : null
+    }, {
+      "type" : "STRING",
+      "name" : "accountName",
+      "optional" : false,
+      "qualifiers" : [ ]
+    }, {
+      "type" : "LONG",
+      "name" : "id",
+      "optional" : false,
+      "qualifiers" : [ ]
+    }, {
+      "type" : "ENUM",
+      "name" : "testEnum",
+      "optional" : false,
+      "qualifiers" : [ ],
+      "values" : [ "ONE", "TWO" ]
+    } ]
+  }, {
+    "type" : "STRING",
+    "name" : "accountNumber",
+    "optional" : false,
+    "qualifiers" : [ {
+      "type" : "ENCRYPTED"
+    }, {
+      "type" : "PII"
+    } ]
+  }, {
+    "type" : "ARRAY",
+    "name" : "strings",
+    "optional" : false,
+    "qualifiers" : [ ],
+    "elementAttribute" : {
+      "type" : "STRING",
+      "name" : "element",
+      "optional" : false,
+      "qualifiers" : [ ]
+    }
+  }, {
+    "type" : "STRING",
+    "name" : "accountId",
+    "optional" : true,
+    "qualifiers" : [ ]
+  }, {
+    "type" : "MAP",
+    "name" : "enumTestDataMap",
+    "optional" : false,
+    "qualifiers" : [ ],
+    "keyAttribute" : {
+      "type" : "STRING",
+      "name" : "key",
+      "optional" : false,
+      "qualifiers" : [ ],
+      "values" : [ "ONE", "TWO" ]
+    },
+    "valueAttribute" : {
+      "type" : "OBJECT",
+      "name" : "value",
+      "optional" : false,
+      "qualifiers" : [ ],
+      "nestedAttributes" : [ {
+        "type" : "OBJECT",
+        "name" : "object",
+        "optional" : false,
+        "qualifiers" : [ ],
+        "nestedAttributes" : null
+      }, {
+        "type" : "STRING",
+        "name" : "name",
+        "optional" : false,
+        "qualifiers" : [ ]
+      }, {
+        "type" : "LONG",
+        "name" : "id",
+        "optional" : false,
+        "qualifiers" : [ ]
+      }, {
+        "type" : "ENUM",
+        "name" : "testEnum",
+        "optional" : false,
+        "qualifiers" : [ ],
+        "values" : [ "ONE", "TWO" ]
+      } ]
+    }
+  } ],
+  "transformationTargets" : [ ]
+}

--- a/leia-schema-validator/src/test/resources/InvalidRecordStubSchema.json
+++ b/leia-schema-validator/src/test/resources/InvalidRecordStubSchema.json
@@ -1,0 +1,43 @@
+{
+  "namespace" : "test",
+  "schemaName" : "TEST_RECORD",
+  "version" : "v1",
+  "description" : "Test Record",
+  "schemaState" : "CREATED",
+  "schemaType" : "JSON",
+  "validationType" : "STRICT",
+  "schemaMeta" : {
+    "createdBy" : "testUser",
+    "createdByEmail" : "testEmail",
+    "createdAt" : 1733897544626,
+    "updatedBy" : null,
+    "updatedByEmail" : null,
+    "updatedAt" : 0
+  },
+  "attributes" : [ {
+    "type" : "INTEGER",
+    "name" : "ttl",
+    "optional" : false,
+    "qualifiers" : [ ]
+  }, {
+    "type" : "STRING",
+    "name" : "accountNumber",
+    "optional" : false,
+    "qualifiers" : [ {
+      "type" : "ENCRYPTED"
+    }, {
+      "type" : "PII"
+    } ]
+  }, {
+    "type" : "STRING",
+    "name" : "accountId",
+    "optional" : true,
+    "qualifiers" : [ ]
+  }, {
+    "type" : "LONG",
+    "name" : "id",
+    "optional" : false,
+    "qualifiers" : [ ]
+  } ],
+  "transformationTargets" : [ ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.leia</groupId>
     <artifactId>leia</artifactId>
-    <version>0.0.1-RC9</version>
+    <version>0.0.1-RC10</version>
     <packaging>pom</packaging>
 
     <name>Leia</name>


### PR DESCRIPTION
-  Introduced LeiaSchemaViolation & ViolationContext for generating violations as part of schema validation
- SchemaValidationUtils - Returns a list of SchemaViolations instead of boolean 
- SchemaValidator - Updated to return all schema validation violations instead of stopping at the first error occurrence
- Fixes ClientMarshaller serialization of empty list responses
- Adds tests for `leia-schema-validator` module
- Upgraded versions across all POM files for the new release