### PR TITLE
Use JsonNode and flag to include source message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.1-RC12]
+
+- LeiaMessageProduceClient
+  - Introduced a flag to control whether the source message should be included during multiplexing.
+  - Modified the message datatype to JsonNode from byte[] to reduce serialization overhead.
+
 ## [0.0.1-RC11]
 
 - MessageProcessor

--- a/leia-bom/pom.xml
+++ b/leia-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
     </parent>
 
     <artifactId>leia-bom</artifactId>

--- a/leia-client-dropwizard/pom.xml
+++ b/leia-client-dropwizard/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/pom.xml
+++ b/leia-client/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>[2.9.0,)</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>

--- a/leia-client/pom.xml
+++ b/leia-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/src/test/java/com/grookage/leia/client/LeiaMessageProduceClientTest.java
+++ b/leia-client/src/test/java/com/grookage/leia/client/LeiaMessageProduceClientTest.java
@@ -17,41 +17,42 @@
 package com.grookage.leia.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.grookage.leia.client.processor.MessageProcessor;
 import com.grookage.leia.client.refresher.LeiaClientRefresher;
 import com.grookage.leia.client.stubs.TargetSchema;
 import com.grookage.leia.client.stubs.TestSchema;
 import com.grookage.leia.client.stubs.TestSchemaUnit;
 import com.grookage.leia.models.ResourceHelper;
-import com.grookage.leia.models.mux.LeiaMessage;
 import com.grookage.leia.models.mux.MessageRequest;
 import com.grookage.leia.models.schema.SchemaDetails;
 import com.grookage.leia.models.schema.SchemaKey;
 import com.grookage.leia.validator.LeiaSchemaValidator;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 class LeiaMessageProduceClientTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
+    private LeiaMessageProduceClient.LeiaMessageProduceClientBuilder<?, ?> schemaClientBuilder;
+    private SchemaKey sourceSchema;
+    private SchemaKey targetSchema;
 
-    @Test
     @SneakyThrows
-    void testLeiaMessageProduceClient() {
+    @BeforeEach
+    void setUp() {
         final var clientRefresher = Mockito.mock(LeiaClientRefresher.class);
         final var schemaValidator = Mockito.mock(LeiaSchemaValidator.class);
-        final var sourceSchema = SchemaKey.builder()
+        sourceSchema = SchemaKey.builder()
                 .namespace("testNamespace")
                 .schemaName("testSchema")
                 .version("V1234")
                 .build();
-        final var targetSchema = SchemaKey.builder()
+        targetSchema = SchemaKey.builder()
                 .namespace("testNamespace")
                 .schemaName("testSchema")
                 .version("v")
@@ -63,11 +64,15 @@ class LeiaMessageProduceClientTest {
         Mockito.when(schemaValidator.getKlass(sourceSchema)).thenReturn(Optional.of(TestSchema.class));
         Mockito.when(schemaValidator.getKlass(targetSchema)).thenReturn(Optional.of(TargetSchema.class));
         Mockito.when(schemaValidator.valid(Mockito.any(SchemaKey.class))).thenReturn(true);
-        final var schemaClient = LeiaMessageProduceClient.builder()
+        schemaClientBuilder = LeiaMessageProduceClient.builder()
                 .mapper(new ObjectMapper())
                 .refresher(clientRefresher)
-                .schemaValidator(schemaValidator)
-                .messageProcessor(() -> messages -> {
+                .schemaValidator(schemaValidator);
+    }
+
+    @Test
+    void testLeiaMessageProduceClient() {
+        final var schemaClient = schemaClientBuilder.messageProcessor(() -> messages -> {
                     Assertions.assertFalse(messages.isEmpty());
                     Assertions.assertEquals(2, messages.size());
                 })
@@ -79,9 +84,30 @@ class LeiaMessageProduceClientTest {
                         .registeredName("testRegisteredName").build()))
                 .build();
         schemaClient.processMessages(MessageRequest.builder()
-                                             .schemaKey(sourceSchema)
-                                             .message(mapper.valueToTree(testSchema))
-                                             .includeSource(true)
-                                             .build());
+                .schemaKey(sourceSchema)
+                .message(mapper.valueToTree(testSchema))
+                .includeSource(true)
+                .build());
+    }
+
+    @Test
+    void testClientWithoutSourceMessage() {
+        final var schemaClient = schemaClientBuilder.messageProcessor(() -> messages -> {
+                    Assertions.assertFalse(messages.isEmpty());
+                    Assertions.assertEquals(1, messages.size());
+                    Assertions.assertEquals("testUser", messages.get(targetSchema).getMessage().get("name").asText());
+                })
+                .build();
+        schemaClient.start();
+        final var testSchema = TestSchema.builder()
+                .userName("testUser")
+                .schemaUnits(List.of(TestSchemaUnit.builder()
+                        .registeredName("testRegisteredName").build()))
+                .build();
+        schemaClient.processMessages(MessageRequest.builder()
+                .schemaKey(sourceSchema)
+                .message(mapper.valueToTree(testSchema))
+                .includeSource(false)
+                .build());
     }
 }

--- a/leia-client/src/test/java/com/grookage/leia/client/LeiaMessageProduceClientTest.java
+++ b/leia-client/src/test/java/com/grookage/leia/client/LeiaMessageProduceClientTest.java
@@ -24,6 +24,7 @@ import com.grookage.leia.client.stubs.TestSchema;
 import com.grookage.leia.client.stubs.TestSchemaUnit;
 import com.grookage.leia.models.ResourceHelper;
 import com.grookage.leia.models.mux.LeiaMessage;
+import com.grookage.leia.models.mux.MessageRequest;
 import com.grookage.leia.models.schema.SchemaDetails;
 import com.grookage.leia.models.schema.SchemaKey;
 import com.grookage.leia.validator.LeiaSchemaValidator;
@@ -77,6 +78,10 @@ class LeiaMessageProduceClientTest {
                 .schemaUnits(List.of(TestSchemaUnit.builder()
                         .registeredName("testRegisteredName").build()))
                 .build();
-        schemaClient.processMessages(sourceSchema, mapper.writeValueAsBytes(testSchema));
+        schemaClient.processMessages(MessageRequest.builder()
+                                             .schemaKey(sourceSchema)
+                                             .message(mapper.valueToTree(testSchema))
+                                             .includeSource(true)
+                                             .build());
     }
 }

--- a/leia-common/pom.xml
+++ b/leia-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-core/pom.xml
+++ b/leia-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard-es/pom.xml
+++ b/leia-dropwizard-es/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard/pom.xml
+++ b/leia-dropwizard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-elastic/pom.xml
+++ b/leia-elastic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-models/pom.xml
+++ b/leia-models/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-models/src/main/java/com/grookage/leia/models/mux/LeiaMessage.java
+++ b/leia-models/src/main/java/com/grookage/leia/models/mux/LeiaMessage.java
@@ -16,6 +16,7 @@
 
 package com.grookage.leia.models.mux;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.grookage.leia.models.schema.SchemaKey;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,6 +26,7 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 
 @AllArgsConstructor
 @Builder
@@ -36,5 +38,5 @@ public class LeiaMessage {
     private SchemaKey schemaKey;
     private List<String> tags = List.of();
     @NotNull
-    private byte[] message;
+    private JsonNode message;
 }

--- a/leia-models/src/main/java/com/grookage/leia/models/mux/MessageRequest.java
+++ b/leia-models/src/main/java/com/grookage/leia/models/mux/MessageRequest.java
@@ -1,0 +1,23 @@
+package com.grookage.leia.models.mux;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.grookage.leia.models.schema.SchemaKey;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@Builder
+@Data
+@NoArgsConstructor
+public class MessageRequest {
+    @NotEmpty
+    private SchemaKey schemaKey;
+    @NotNull
+    private JsonNode message;
+    boolean includeSource;
+}

--- a/leia-parent/pom.xml
+++ b/leia-parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-bom</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-bom</relativePath>
     </parent>
 

--- a/leia-refresher/pom.xml
+++ b/leia-refresher/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-repository/pom.xml
+++ b/leia-repository/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-schema-validator/pom.xml
+++ b/leia-schema-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC11</version>
+        <version>0.0.1-RC12</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.leia</groupId>
     <artifactId>leia</artifactId>
-    <version>0.0.1-RC11</version>
+    <version>0.0.1-RC12</version>
     <packaging>pom</packaging>
 
     <name>Leia</name>


### PR DESCRIPTION
- LeiaMessageProduceClient
  - Introduced a flag to control whether the source message should be included during multiplexing.
  - Modified the message datatype to JsonNode from byte[] to reduce serialization overhead.