### PR TITLE
Use dropwizard lifecyle to initialize and add start method in leiaRefresher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.1-RC13]
+
+- LeiaClientBundle: Use dropwizard lifecyle to initialize the validator, refresher and producer client
+- LeiaRefresher: Add a start method to initialize data instead of doing it in constructor 
+
 ## [0.0.1-RC12]
 
 - LeiaMessageProduceClient

--- a/leia-bom/pom.xml
+++ b/leia-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
     </parent>
 
     <artifactId>leia-bom</artifactId>

--- a/leia-client-dropwizard/pom.xml
+++ b/leia-client-dropwizard/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/pom.xml
+++ b/leia-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-common/pom.xml
+++ b/leia-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-core/pom.xml
+++ b/leia-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-core/src/main/java/com/grookage/leia/core/retrieval/SchemaRetriever.java
+++ b/leia-core/src/main/java/com/grookage/leia/core/retrieval/SchemaRetriever.java
@@ -56,6 +56,7 @@ public class SchemaRetriever {
                     .refreshTimeInSeconds(cacheConfig.getRefreshCacheSeconds())
                     .periodicRefresh(true)
                     .build();
+            refresher.start();
         }
     }
 

--- a/leia-core/src/test/java/com/grookage/leia/core/retrieval/RepositoryRefresherTest.java
+++ b/leia-core/src/test/java/com/grookage/leia/core/retrieval/RepositoryRefresherTest.java
@@ -24,6 +24,7 @@ import com.grookage.leia.models.utils.LeiaUtils;
 import com.grookage.leia.provider.exceptions.RefresherErrorCode;
 import com.grookage.leia.provider.exceptions.RefresherException;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,6 +42,7 @@ class RepositoryRefresherTest {
                 .build();
         Mockito.when(supplier.get()).thenReturn(registry);
         final var refresher = new RepositoryRefresher(supplier, 5, true);
+        refresher.start();
         Assertions.assertTrue(refresher.getData().getSchemas().isEmpty());
         registry.add(schemaDetails);
         LeiaUtils.sleepFor(6);
@@ -57,8 +59,9 @@ class RepositoryRefresherTest {
     void testRepositoryRefresher_whenSupplierReturnNullAtStart() {
         final var supplier = Mockito.mock(RepositorySupplier.class);
         Mockito.doReturn(null).when(supplier).get();
+        val repositoryRefresher = new RepositoryRefresher(supplier, 5, true);
         final var exception = Assertions.assertThrows(RefresherException.class,
-                () -> new RepositoryRefresher(supplier, 5, true));
+                repositoryRefresher::start);
         Assertions.assertNotNull(exception);
         Assertions.assertEquals(RefresherErrorCode.REFRESH_FAILED.getStatus(), exception.getStatus());
     }
@@ -67,8 +70,9 @@ class RepositoryRefresherTest {
     void testRepositoryRefresher_whenSupplierThrowExceptionAtStart() {
         final var supplier = Mockito.mock(RepositorySupplier.class);
         Mockito.doThrow(RefresherException.error(RefresherErrorCode.REFRESH_FAILED)).when(supplier).get();
+        val repositoryRefresher = new RepositoryRefresher(supplier, 5, true);
         final var exception = Assertions.assertThrows(RefresherException.class,
-                () -> new RepositoryRefresher(supplier, 5, true));
+                repositoryRefresher::start);
         Assertions.assertNotNull(exception);
         Assertions.assertEquals(RefresherErrorCode.REFRESH_FAILED.getStatus(), exception.getStatus());
     }

--- a/leia-dropwizard-es/pom.xml
+++ b/leia-dropwizard-es/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard/pom.xml
+++ b/leia-dropwizard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-elastic/pom.xml
+++ b/leia-elastic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-models/pom.xml
+++ b/leia-models/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-parent/pom.xml
+++ b/leia-parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-bom</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-bom</relativePath>
     </parent>
 

--- a/leia-refresher/pom.xml
+++ b/leia-refresher/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-refresher/src/main/java/com/grookage/leia/provider/refresher/AbstractLeiaRefresher.java
+++ b/leia-refresher/src/main/java/com/grookage/leia/provider/refresher/AbstractLeiaRefresher.java
@@ -35,7 +35,6 @@ public abstract class AbstractLeiaRefresher<T> implements LeiaRefresher<T> {
                 TimeUnit.SECONDS,
                 periodicRefresh
         );
-        this.dataProvider.start();
     }
 
     @Override
@@ -46,5 +45,10 @@ public abstract class AbstractLeiaRefresher<T> implements LeiaRefresher<T> {
     @Override
     public void refresh() {
         dataProvider.update();
+    }
+
+    @Override
+    public void start() {
+        this.dataProvider.start();
     }
 }

--- a/leia-refresher/src/main/java/com/grookage/leia/provider/refresher/LeiaRefresher.java
+++ b/leia-refresher/src/main/java/com/grookage/leia/provider/refresher/LeiaRefresher.java
@@ -22,4 +22,5 @@ public interface LeiaRefresher<T> {
 
     void refresh();
 
+    void start();
 }

--- a/leia-repository/pom.xml
+++ b/leia-repository/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-schema-validator/pom.xml
+++ b/leia-schema-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.leia</groupId>
     <artifactId>leia</artifactId>
-    <version>0.0.1-RC12</version>
+    <version>0.0.1-RC13</version>
     <packaging>pom</packaging>
 
     <name>Leia</name>


### PR DESCRIPTION
- LeiaClientBundle: Use dropwizard lifecyle to initialize the validator, refresher and producer client
- LeiaRefresher: Add a start method to initialize data instead of doing it in constructor 