### PR TITLE
Aerospike Client Usage Bug

### DIFF
--- a/leia-aerospike/src/main/java/com/grookage/leia/aerospike/client/AerospikeClientUtils.java
+++ b/leia-aerospike/src/main/java/com/grookage/leia/aerospike/client/AerospikeClientUtils.java
@@ -6,11 +6,18 @@ import com.aerospike.client.query.IndexType;
 import com.grookage.leia.aerospike.exception.LeiaAeroErrorCode;
 import com.grookage.leia.aerospike.storage.AerospikeStorageConstants;
 import com.grookage.leia.models.exception.LeiaException;
+import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 @UtilityClass
 @Slf4j
@@ -65,6 +72,7 @@ public class AerospikeClientUtils {
         final var writePolicy = getWritePolicy(config);
         final var scanPolicy = getScanPolicy(config);
         final var batchPolicy = getBatchPolicy(config);
+        final var queryPolicy = getQueryPolicy(config);
 
         clientPolicy.user = config.getUsername();
         clientPolicy.password = config.getPassword();
@@ -73,6 +81,7 @@ public class AerospikeClientUtils {
         clientPolicy.writePolicyDefault = writePolicy;
         clientPolicy.scanPolicyDefault = scanPolicy;
         clientPolicy.batchPolicyDefault = batchPolicy;
+        clientPolicy.queryPolicyDefault = queryPolicy;
         clientPolicy.failIfNotConnected = true;
         clientPolicy.threadPool = Executors.newFixedThreadPool(config.getThreadPoolSize());
 
@@ -80,7 +89,14 @@ public class AerospikeClientUtils {
             clientPolicy.tlsPolicy = new TlsPolicy();
         }
         return clientPolicy;
+    }
 
+    public QueryPolicy getQueryPolicy(final AerospikeConfig config) {
+        final var queryPolicy = new QueryPolicy();
+        queryPolicy.readModeAP = ReadModeAP.ONE;
+        queryPolicy.replica = Replica.MASTER_PROLES;
+        queryPolicy.maxConcurrentNodes = config.getBatchMaxConcurrentNodes();
+        return queryPolicy;
     }
 
     public BatchPolicy getBatchPolicy(final AerospikeConfig config) {
@@ -119,5 +135,29 @@ public class AerospikeClientUtils {
         readPolicy.totalTimeout = config.getTimeout();
         readPolicy.sendKey = true;
         return readPolicy;
+    }
+
+    @SneakyThrows
+    public static byte[] compress(final byte[] bytes) {
+        final var bos = new ByteArrayOutputStream();
+        final var gzip = new GZIPOutputStream(bos);
+        gzip.write(bytes);
+        gzip.close();
+        return bos.toByteArray();
+    }
+
+    @SneakyThrows
+    public static String retrieve(final byte[] value) {
+        final var gis = new GZIPInputStream(
+                new ByteArrayInputStream(
+                        value
+                ));
+        final var bf = new BufferedReader(new InputStreamReader(gis));
+        final var stringBuilder = new StringBuilder();
+        String line;
+        while ((line = bf.readLine()) != null) {
+            stringBuilder.append(line);
+        }
+        return stringBuilder.toString();
     }
 }

--- a/leia-aerospike/src/main/java/com/grookage/leia/aerospike/repository/AerospikeRepository.java
+++ b/leia-aerospike/src/main/java/com/grookage/leia/aerospike/repository/AerospikeRepository.java
@@ -53,12 +53,12 @@ public class AerospikeRepository extends AbstractSchemaRepository {
 
     @Override
     public void create(SchemaDetails configDetails) {
-        aerospikeManager.create(toStorageRecord(configDetails));
+        aerospikeManager.save(toStorageRecord(configDetails));
     }
 
     @Override
     public void update(SchemaDetails configDetails) {
-        aerospikeManager.update(toStorageRecord(configDetails));
+        aerospikeManager.save(toStorageRecord(configDetails));
     }
 
     @Override


### PR DESCRIPTION
Fixed a weird bug with Aerospike usage. If there are no records OR only one record, Predicates don't work .and/.or, they need to be handled separately. Their [examples](https://github.com/aerospike/aerospike-client-java/blob/master/examples/src/com/aerospike/examples/QueryExp.java) and [forum](https://discuss.aerospike.com/t/querying-for-records-with-a-large-number-of-keys/11214) infact endorse the original code written, but found it during execution. After some semantic trials on aql - a large cup of coffee later - arrived at the structure that seems to work.

Also added compression to records