### PR TITLE
fixed a bug : multiple update events not populating in histories item of schema

### DIFF
--- a/leia-models/src/main/java/com/grookage/leia/models/schema/SchemaHistoryItem.java
+++ b/leia-models/src/main/java/com/grookage/leia/models/schema/SchemaHistoryItem.java
@@ -39,20 +39,5 @@ public class SchemaHistoryItem {
     String configUpdaterId;
     String configUpdaterEmail;
 
-    @Override
-    public int hashCode() {
-        return this.getSchemaEvent().hashCode();
-    }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || obj.getClass() != this.getClass()) {
-            return false;
-        }
-        final var thatKey = (SchemaHistoryItem) obj;
-        return (thatKey.getSchemaEvent().equals(this.schemaEvent));
-    }
 }


### PR DESCRIPTION
Bug:
When updating a schema multiple times, all UPDATE_SCHEMA events should be added to the histories. but only the first SchemaHistoryItem was stored
Fix: 
Removed the overridden equals() and hashCode() methods from SchemaHistoryItem, which previously caused the Set<SchemaHistoryItem> to treat items with the same schemaEvent as same. 

