### PR TITLE
Upgrade apache http client to prevent Invalid Proxy bug

### DIFF
--- a/leia-http-processor/pom.xml
+++ b/leia-http-processor/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
-        <http.client.version>5.2.2</http.client.version>
+        <http.client.version>5.5</http.client.version>
         <q.version>0.7.0</q.version>
         <wiremock.version>3.3.1</wiremock.version>
     </properties>

--- a/leia-http-processor/src/main/java/com/grookage/leia/http/processor/HttpMessageExecutor.java
+++ b/leia-http-processor/src/main/java/com/grookage/leia/http/processor/HttpMessageExecutor.java
@@ -135,7 +135,7 @@ public abstract class HttpMessageExecutor<T> implements MessageExecutor {
                 return response;
             });
         } catch (Exception e) {
-            log.error("Sending to the backend {} has failed with exception {}", backendConfig, e.getMessage());
+            log.error("Sending to the backend {} has failed with exception {}", backendConfig, e.getMessage(), e);
             throw LeiaException.error(LeiaHttpErrorCode.EVENT_SEND_FAILED, e);
         }
     }


### PR DESCRIPTION
When using a outbound proxy, the apache http client is throwing the error "Invalid Proxy" during socket creation.
Ref: https://stackoverflow.com/questions/77611986/invalid-proxy-for-apache-httpclient5-with-get 

Recommended solution is to upgrade the apache http client.