### PR TITLE
Propagate MDC context across async threads

### DIFF
--- a/leia-aerospike-dw/pom.xml
+++ b/leia-aerospike-dw/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-aerospike/pom.xml
+++ b/leia-aerospike/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-bom/pom.xml
+++ b/leia-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>leia-bom</artifactId>

--- a/leia-client-dropwizard/pom.xml
+++ b/leia-client-dropwizard/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/pom.xml
+++ b/leia-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-client/src/main/java/com/grookage/leia/client/LeiaMessageProduceClient.java
+++ b/leia-client/src/main/java/com/grookage/leia/client/LeiaMessageProduceClient.java
@@ -74,7 +74,7 @@ public class LeiaMessageProduceClient extends AbstractSchemaClient {
 	                                            TransformationTarget transformationTarget,
 	                                            TargetValidator tValidator) {
 		if (!validTarget(messageRequest, sourceSchema, transformationTarget, tValidator)) {
-			log.error("Transformation target {} is not valid for source schemaKey {}",
+			log.debug("Transformation target {} is not valid for source schemaKey {}",
 					transformationTarget.getSchemaKey().getReferenceId(), messageRequest.getSchemaKey().getReferenceId());
 			return Optional.empty();
 		}

--- a/leia-common/pom.xml
+++ b/leia-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-core/pom.xml
+++ b/leia-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard-es/pom.xml
+++ b/leia-dropwizard-es/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-dropwizard/pom.xml
+++ b/leia-dropwizard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-elastic/pom.xml
+++ b/leia-elastic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-http-processor/pom.xml
+++ b/leia-http-processor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-models/pom.xml
+++ b/leia-models/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-parent/pom.xml
+++ b/leia-parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-bom</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-bom</relativePath>
     </parent>
 

--- a/leia-processor/pom.xml
+++ b/leia-processor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-processor/src/main/java/com/grookage/leia/mux/DefaultMessageProcessor.java
+++ b/leia-processor/src/main/java/com/grookage/leia/mux/DefaultMessageProcessor.java
@@ -25,9 +25,11 @@ import com.grookage.leia.mux.executor.MessageExecutor;
 import com.grookage.leia.mux.executor.MessageExecutorFactory;
 import com.grookage.leia.mux.filter.BackendFilter;
 import com.grookage.leia.mux.resolver.BackendNameResolver;
+import com.grookage.leia.mux.util.MdcUtils;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -97,10 +99,12 @@ public class DefaultMessageProcessor implements MessageProcessor {
 			log.debug("Haven't found any eligible executors with the set of messages {}", messages);
 			return;
 		}
+		
+		final Map<String, String> mdcContext = MDC.getCopyOfContextMap();
 		final var futures = CompletableFuture.allOf(
 				executorMapping.entrySet().stream()
 						.map(each -> CompletableFuture.runAsync(
-								() -> each.getKey().send(each.getValue())))
+								MdcUtils.decorateWithMdc(() -> each.getKey().send(each.getValue()), mdcContext)))
 						.toArray(CompletableFuture[]::new));
 		try {
 			futures.get(getProcessingThresholdMs(), TimeUnit.MILLISECONDS);

--- a/leia-processor/src/main/java/com/grookage/leia/mux/util/MdcUtils.java
+++ b/leia-processor/src/main/java/com/grookage/leia/mux/util/MdcUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024-2025. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.mux.util;
+
+import lombok.experimental.UtilityClass;
+import org.slf4j.MDC;
+
+import java.util.Map;
+
+@UtilityClass
+public class MdcUtils {
+	public static Runnable decorateWithMdc(Runnable task, Map<String, String> mdcContext) {
+		return () -> {
+			if (mdcContext != null) {
+				MDC.setContextMap(mdcContext);
+			}
+			try {
+				task.run();
+			} finally {
+				MDC.clear();
+			}
+		};
+	}
+}

--- a/leia-repository/pom.xml
+++ b/leia-repository/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/leia-schema-validator/pom.xml
+++ b/leia-schema-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.grookage.leia</groupId>
         <artifactId>leia-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>../leia-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.leia</groupId>
     <artifactId>leia</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>pom</packaging>
 
     <name>Leia</name>


### PR DESCRIPTION
MDC is ThreadLocal and doesn't automatically transfer when CompletableFuture.runAsync() switches to ForkJoinPool worker threads ,this causes MDC context to be lost during async execution. 
The fix captures MDC before creating async tasks, restores it in each worker thread, and clears it after completion in finally block