### PR TITLE
Adding support of SerdeLeiaMessageValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.2]
+
+- Added `SerdeLeiaMessageValidator` to validate transformed Leia message payloads by deserializing them
+  into client classes using the configured Jackson `ObjectMapper`.
+- Added MdcUtils to propagate MDC context across asynchronous message-processing threads.
 ## [1.1.1]
 - `DefaultLeiaMessageValidator`- Bug fix: Fixed validation exception being thrown for optional attributes with null values
 ## [1.1.0]

--- a/leia-client-dropwizard/src/main/java/com/grookage/leia/dw/client/LeiaClientBundle.java
+++ b/leia-client-dropwizard/src/main/java/com/grookage/leia/dw/client/LeiaClientBundle.java
@@ -86,6 +86,10 @@ public abstract class LeiaClientBundle<T extends Configuration> implements Confi
 		return new DefaultLeiaMessageValidator();
 	}
 
+	protected LeiaMessageValidator getMessageValidator(T configuration, Environment environment) {
+		return getMessageValidator(configuration);
+	}
+
 	@Override
 	public void run(T configuration, Environment environment) {
 		final var clientRequestSupplier = getClientRequestSupplier(configuration);
@@ -129,7 +133,7 @@ public abstract class LeiaClientBundle<T extends Configuration> implements Confi
 					.mapper(environment.getObjectMapper())
 					.processorSupplier(getMessageProcessor(configuration))
 					.targetValidator(getTargetRetriever(configuration))
-					.leiaMessageValidator(getMessageValidator(configuration))
+					.leiaMessageValidator(getMessageValidator(configuration, environment))
 					.build();
 			environment.lifecycle().manage(new Managed() {
 				@Override

--- a/leia-common/src/main/java/com/grookage/leia/common/validation/LeiaSchemaClassProvider.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/validation/LeiaSchemaClassProvider.java
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-package com.grookage.leia.validator;
+package com.grookage.leia.common.validation;
 
-import com.grookage.leia.common.validation.LeiaSchemaClassProvider;
 import com.grookage.leia.models.schema.SchemaKey;
 
-public interface LeiaSchemaValidator extends LeiaSchemaClassProvider {
+import java.util.Optional;
 
-	void start();
+public interface LeiaSchemaClassProvider {
 
-	void stop();
-
-	boolean valid(SchemaKey schemaKey);
-
+	Optional<Class<?>> getKlass(SchemaKey schemaKey);
 }

--- a/leia-common/src/main/java/com/grookage/leia/common/validation/SerdeLeiaMessageValidator.java
+++ b/leia-common/src/main/java/com/grookage/leia/common/validation/SerdeLeiaMessageValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024. Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grookage.leia.common.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grookage.leia.common.violation.LeiaMessageViolation;
+import com.grookage.leia.common.violation.LeiaMessageViolationImpl;
+import com.grookage.leia.models.schema.SchemaDetails;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+public class SerdeLeiaMessageValidator implements LeiaMessageValidator {
+
+	private final LeiaSchemaClassProvider schemaClassProvider;
+	private final ObjectMapper mapper;
+
+	public SerdeLeiaMessageValidator(final LeiaSchemaClassProvider schemaClassProvider, final ObjectMapper mapper) {
+        this.schemaClassProvider = Objects.requireNonNull(schemaClassProvider, "LeiaSchemaClassProvider must not be null");
+        this.mapper = Objects.requireNonNull(mapper, "ObjectMapper must not be null");
+	}
+
+	@Override
+	public List<LeiaMessageViolation> validate(final SchemaDetails schemaDetails, final JsonNode message) {
+		final var schemaKey = schemaDetails.getSchemaKey();
+		final var registeredClass = schemaClassProvider.getKlass(schemaKey).orElse(null);
+		if (registeredClass == null) {
+			log.debug("No registered class found for schemaKey {}; skipping Serde validation",
+					schemaKey.getReferenceId());
+			return List.of();
+		}
+
+		try {
+			mapper.treeToValue(message, registeredClass);
+			return List.of();
+		} catch (Exception exception) {
+			log.debug("Serde validation failed for schemaKey {} and class {}",
+					schemaKey.getReferenceId(), registeredClass.getName(), exception);
+			return List.of(LeiaMessageViolationImpl.builder()
+					.schemaKey(schemaKey)
+					.fieldPath("root")
+					.message("Deserialization into class " + registeredClass.getSimpleName()
+							+ " failed: " + exception.getMessage())
+					.build());
+		}
+	}
+}

--- a/leia-common/src/test/java/com/grookage/leia/common/validation/SerdeLeiaMessageValidatorTest.java
+++ b/leia-common/src/test/java/com/grookage/leia/common/validation/SerdeLeiaMessageValidatorTest.java
@@ -1,0 +1,169 @@
+package com.grookage.leia.common.validation;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grookage.leia.common.violation.LeiaMessageViolation;
+import com.grookage.leia.models.attributes.StringAttribute;
+import com.grookage.leia.models.schema.SchemaDetails;
+import com.grookage.leia.models.schema.SchemaKey;
+import com.grookage.leia.models.schema.SchemaValidationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SerdeLeiaMessageValidatorTest {
+
+	private static final SchemaKey SCHEMA_KEY = SchemaKey.builder()
+			.namespace("marketplace")
+			.schemaName("merchant_common_bfo")
+			.version("v1")
+			.orgId("testOrg")
+			.type("default")
+			.tenantId("testTenant")
+			.build();
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final SchemaDetails SCHEMA_DETAILS = SchemaDetails.builder()
+			.schemaKey(SCHEMA_KEY)
+			.attributes(Set.of(new StringAttribute("milestone", false, Set.of())))
+			.validationType(SchemaValidationType.STRICT)
+			.build();
+	private SerdeLeiaMessageValidator validator;
+
+	@BeforeEach
+	void setUp() {
+		validator = new SerdeLeiaMessageValidator(
+				schemaKey -> Optional.of(MilestoneEventData.class), MAPPER);
+	}
+
+	@Test
+	void acceptsSubtype() throws Exception {
+		assertAccepted("""
+				{
+				  "milestone": "CLIENT_ONLY_SUBTYPE",
+				  "clientOnlyField": "value",
+				  "priority": 1,
+				  "status": "SUCCESS"
+				}
+				""");
+
+        assertAccepted("""
+				{
+				  "milestone": "PARTNER_SUBTYPE",
+				  "partnerId": "partner-1",
+				  "retryable": true
+				}
+				""");
+
+        assertAccepted("""
+				{
+				  "milestone": "PARTNER_SUBTYPE",
+				  "partnerId": "partner-2",
+				  "retryable": null
+				}
+				""");
+	}
+
+	@Test
+	void rejectsInvalidPayloads() {
+		assertAll(
+				() -> assertRejected("""
+						{
+						  "milestone": "UNKNOWN_SUBTYPE"
+						}
+						""", "Could not resolve type id"),
+				() -> assertRejected("""
+						{
+						  "milestone": "CLIENT_ONLY_SUBTYPE",
+						  "unknownField": "value"
+						}
+						""", "Unrecognized field"),
+				() -> assertRejected("""
+						{
+						  "milestone": "CLIENT_ONLY_SUBTYPE",
+						  "priority": {
+						    "value": 1
+						  }
+						}
+						""", "Cannot deserialize value of type `int`"),
+				() -> assertRejected("""
+						{
+						  "milestone": "CLIENT_ONLY_SUBTYPE",
+						  "status": "UNKNOWN"
+						}
+						""", "not one of the values accepted for Enum class")
+		);
+	}
+
+	@Test
+	void skipsUnregisteredSchema() throws Exception {
+		final var validatorWithoutRegisteredClass =
+				new SerdeLeiaMessageValidator(schemaKey -> Optional.empty(), MAPPER);
+
+		assertTrue(validatorWithoutRegisteredClass.validate(
+				SCHEMA_DETAILS, readMessage("""
+						{
+						  "milestone": "UNKNOWN_SUBTYPE"
+						}
+						""")).isEmpty());
+	}
+
+	private void assertAccepted(final String payload) throws Exception {
+		final var message = readMessage(payload);
+
+		assertFalse(new DefaultLeiaMessageValidator().validate(SCHEMA_DETAILS, message).isEmpty());
+		assertTrue(validator.validate(SCHEMA_DETAILS, message).isEmpty());
+	}
+
+	private void assertRejected(final String payload,
+	                            final String expectedCause) throws Exception {
+		final List<LeiaMessageViolation> violations =
+				validator.validate(SCHEMA_DETAILS, readMessage(payload));
+
+		assertEquals(1, violations.size());
+		final var violation = violations.get(0);
+		assertEquals(SCHEMA_KEY, violation.schemaKey());
+		assertEquals("root", violation.fieldPath());
+		assertTrue(violation.message().contains(
+				"Deserialization into class MilestoneEventData failed"));
+		assertTrue(violation.message().contains(expectedCause));
+	}
+
+	private JsonNode readMessage(final String payload) throws Exception {
+		return MAPPER.readTree(payload);
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "milestone", visible = true)
+	@JsonSubTypes({
+			@JsonSubTypes.Type(value = ClientOnlyMilestoneEventData.class, name = "CLIENT_ONLY_SUBTYPE"),
+			@JsonSubTypes.Type(value = PartnerMilestoneEventData.class, name = "PARTNER_SUBTYPE")
+	})
+	private static class MilestoneEventData {
+		public String milestone;
+	}
+
+	private static class ClientOnlyMilestoneEventData extends MilestoneEventData {
+		public String clientOnlyField;
+		public int priority;
+		public MilestoneStatus status;
+	}
+
+	private static class PartnerMilestoneEventData extends MilestoneEventData {
+		public String partnerId;
+		public boolean retryable;
+	}
+
+	private enum MilestoneStatus {
+		SUCCESS,
+		FAILED
+	}
+}


### PR DESCRIPTION
Introduced an optional SerdeLeiaMessageValidator  that resolves the registered client-side schema classes and validates the transformed Leia payload through Jackson deserialisation

This enables validation to follow the client’s actual data model, including polymorphic subtypes and type-specific fields that may not be fully present on server side. Objective is to provide backward compatibility to old clients while maintaining the existing default Leia message validation behaviour 